### PR TITLE
Logic fix 

### DIFF
--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -555,10 +555,15 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
             # deal with change in clinical indication-panel interaction
             # e.g. clinical indication R1 changed from panel 1 to panel 2
             for cip in ClinicalIndicationPanel.objects.filter(
-                clinical_indication_id=ci_instance.id,
+                clinical_indication_id__r_code=ci_instance.r_code,
                 current=True,
             ):
-                if cip.panel_id not in indication["panels"]:
+                associated_panel = Panel.objects.get(id=cip.panel_id)
+
+                if (
+                    associated_panel.external_id
+                    and associated_panel.external_id not in indication["panels"]
+                ):
                     with transaction.atomic():
                         cip.pending = True
                         cip.current = False

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -558,8 +558,12 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
                 clinical_indication_id__r_code=ci_instance.r_code,
                 current=True,
             ):
+                # grab associated panel
                 associated_panel = Panel.objects.get(id=cip.panel_id)
 
+                # if for the clinical indication
+                # the associated panel association is not in test directory
+                # flag for review
                 if (
                     associated_panel.external_id
                     and associated_panel.external_id not in indication["panels"]

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -368,6 +368,12 @@ class PanelGene(models.Model):
         max_length=255,
     )
 
+    # needed for PanelGene backward deactivation purpose
+    pending = models.BooleanField(
+        verbose_name="Pending Activation",
+        default=False,
+    )
+
     class Meta:
         db_table = "panel_gene"
 

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -140,7 +140,7 @@ class ClinicalIndicationPanel(models.Model):
     current = models.BooleanField(verbose_name="latest association")
 
     pending = models.BooleanField(
-        verbose_name="pending activation",
+        verbose_name="pending review",
         null=True,
         default=False,
     )
@@ -370,7 +370,7 @@ class PanelGene(models.Model):
 
     # needed for PanelGene backward deactivation purpose
     pending = models.BooleanField(
-        verbose_name="Pending Activation",
+        verbose_name="Pending Review",
         default=False,
     )
 


### PR DESCRIPTION
- check if ci-panel link is still in seeded test directory, if not, flag for review
- if panel is not created, any future panel-gene interaction need to be flagged for review
- similarly, if panel is not created, panel will go through function `_backward_deactive_panel_gene` to flag any panel-gene that have dropped below confidence 3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/24)
<!-- Reviewable:end -->
