### PR TITLE
limit long hgncs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build: .
     command: bash -c "python manage.py collectstatic --noinput && gunicorn panel_requests.wsgi:application --bind :8009"
     env_file:
-      - /home/jason/github/eris/.env
+      - .env # change to relative path when docker compose build
     volumes:
       - eris_static:/app/staticfiles
     expose:

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -204,9 +204,13 @@ def _make_panels_from_hgncs(
 
     conf, moi, mop, pen = _retrieve_unknown_metadata_records()
 
+    # TODO: limit hgncs panel name length
+    panel_name = ",".join(sorted(hgnc_list))
+    formatted_panel_name = panel_name[:200] if len(panel_name) > 220 else panel_name
+
     # create Panel record only when HGNC difference
     panel_instance, panel_created = Panel.objects.get_or_create(
-        panel_name=",".join(hgnc_list),
+        panel_name=formatted_panel_name,
         test_directory=True,
         defaults={
             "panel_source": unique_td_source,

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
@@ -206,3 +206,27 @@ class TestMakePanelsFromHgncs(TestCase):
     # the clinical indication will be linked to it (and both old and new will be flagged for review)
     # this is different from the panel-gene interaction where panel get their genes from PanelApp API
     # thus there's a need to monitor the changes in panel-gene relationship
+
+    def test_long_hgnc_list(self):
+        """
+        scenario where there's a long list of hgncs and db limit for CharField
+        is only 255 chars thus there is a need to limit panel name to 200 chars
+        if length exceed 255
+
+        we expect the function to truncate the panel name to 200 chars and store it in db
+        """
+        mock_test_directory = {
+            "td_source": "rare-and-inherited-disease-national-gnomic-test-directory-v5.2.xlsx",
+            "config_source": "230401_RD",
+            "date": "230616",
+        }
+
+        hgncs = [f"HGNC:{i}" for i in range(1000)]
+
+        _make_panels_from_hgncs(
+            mock_test_directory, self.first_clinical_indication, hgncs
+        )
+
+        panel = Panel.objects.first()
+
+        assert len(panel.panel_name) == 200  # assert that panel name length is 200


### PR DESCRIPTION
- limit panel name to 200 chars if length more than 220
- added testing this in unit testing

## Unit Test
```
(env) jason@Jasons-MBA eris % python manage.py test
Found 63 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
.Inserting test directory data into database...
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
...........None: No Panel record has panelapp ID 999
..........For panel Acute rhabdomyolyosis, skipping gene without HGNC ID: acyl-CoA dehydrogenase family member 9
..............................
----------------------------------------------------------------------
Ran 63 tests in 3.996s

OK
Destroying test database for alias 'default'...
```