### PR TITLE
minor fix

### DIFF
--- a/web/templates/web/info/clinical.html
+++ b/web/templates/web/info/clinical.html
@@ -17,7 +17,11 @@
             {% if ci %}
             <h1>{{ ci.name }}</h1>
             <h4>r code: {{ ci.r_code }}</h4>
-            <h4>test method: {{ ci.test_method }}</h4>
+            {% if ci.test_method %}
+                <h4>test method: {{ ci.test_method }}</h4>
+            {% else %}
+                <h4>test method: None</h4>
+            {% endif %}
             <h5>database id: <span class="text-danger">{{ ci.id }}</span></h5>
             {% else %}
             <h1>Clinical Indication Does Not Exist.</h1>
@@ -178,8 +182,8 @@
                     <h5 class="card-title">panel id: <span class="text-info">{{ key }}</span></h5>
 
                     <p class="card-text">
-                        <table class="table table-bordered table-hover">
-                            <thead>
+                        <table class="table pt-2" id="geneTable">
+                            <thead class="table-success">
                             <tr>
                                 <th scope="col">HGNC id</th>
                                 <th scope="col">Gene Symbol</th>
@@ -189,7 +193,7 @@
                             <tbody>
                                 {% for gene in values %}
                                 <tr>
-                                    <td><a href="{% url 'gene' gene.id %}">{{ gene.hgnc }}</a></td>
+                                    <td><a href="{% url 'gene' gene.gene_id %}">{{ gene.hgnc }}</a></td>
                                     <td>{{ gene.symbol }}</td>
                                     <td>{{ gene.created }}</td>
                                 </tr>
@@ -216,8 +220,8 @@
     <div class="row">
         {% if transcripts %}
         <div class="col-12">
-            <table class="table table-bordered shadow">
-                <thead>
+            <table class="table pt-2" id="transcriptTable">
+                <thead class="table-success">
                 <tr>
                     <th scope="col">Gene</th>
                     <th scope="col">Transcript</th>
@@ -249,4 +253,13 @@
     </div>
 
 </div>
+{% endblock %}
+
+{% block script %}
+<script>
+    $(document).ready(function () {
+        new DataTable('#geneTable');
+        new DataTable('#transcriptTable');
+    });
+</script>
 {% endblock %}

--- a/web/templates/web/info/gene.html
+++ b/web/templates/web/info/gene.html
@@ -7,7 +7,9 @@
             {% if gene %}
             <h1>{{ gene.hgnc_id }}</h1>
             <h4>{{ gene.gene_symbol }}</h4>
-            <h4>alias symbols: {{ gene.alias_symbols }}</h4>
+            {% if gene.alias_symbols %}
+                <h4>alias symbols: {{ gene.alias_symbols }}</h4>
+            {% endif %}
             <h5>database id: {{ gene.id }}</h5>
             {% else %}
             <h1>Gene Does Not Exist.</h1>
@@ -37,7 +39,7 @@
                         {% else %}
                         <li class="list-group-item">custom panel: <span class="badge text-bg-danger">{{ panel.panel_id__custom }}</span></li>
                         {% endif %}
-                        <li class="list-group-item">created: {{ panel.panel_id__created_date }} {{ panel.panel_id__created_time }}</li>
+                        <li class="list-group-item">created: {{ panel.panel_id__created }}</li>
                     </ul>
                 </div>
             </div>

--- a/web/templates/web/info/gene.html
+++ b/web/templates/web/info/gene.html
@@ -9,6 +9,8 @@
             <h4>{{ gene.gene_symbol }}</h4>
             {% if gene.alias_symbols %}
                 <h4>alias symbols: {{ gene.alias_symbols }}</h4>
+            {% else %}
+                <h4>alias symbols: None</h4>
             {% endif %}
             <h5>database id: {{ gene.id }}</h5>
             {% else %}

--- a/web/templates/web/info/panel.html
+++ b/web/templates/web/info/panel.html
@@ -16,13 +16,17 @@
         <div class="col">
             {% if panel %}
             <h1>{{ panel.panel_name }}</h1>
+            {% if panel.external_id %}
             <h4>external id: {{ panel.external_id }}</h4>
+            {% else %}
+            <h4>external id: None</h4>
+            {% endif %}
             <h4>panel source: {{ panel.panel_source }}</h4>
             <h4>test directory: {{ panel.test_directory }}</h4>
             {% if panel.panel_version %}
-            <h4>panel version: {{ panel.panel_version }}</h4>
+                <h4>panel version: {{ panel.panel_version }}</h4>
             {% else %}
-            <h4>panel version: None</h4>
+                <h4>panel version: None</h4>
             {% endif %}
             <h4>custom: {{ panel.custom }}</h4>
             <h4>created: {{ panel.created }}</h4>
@@ -99,7 +103,11 @@
 
                     <ul class="list-group">
                         <li class="list-group-item">r code: {{ ci.r_code }}</li>
+                        {% if ci.test_method %}
                         <li class="list-group-item">test method: {{ ci.test_method }}</li>
+                        {% else %}
+                        <li class="list-group-item">test method: None</li>
+                        {% endif %}
                     </ul>
                 </div>
             </div>
@@ -159,8 +167,8 @@
     <div class="row">
         {% if pgs %}
         <div class="col">
-            <table class="table table-bordered shadow">
-                <thead>
+            <table id="geneTable" class="table pt-2">
+                <thead class="table-success">
                   <tr>
                     <th scope="col">HGNC ID</th>
                     <th scope="col">Gene Symbol</th>
@@ -191,8 +199,8 @@
     <div class="row">
         {% if transcripts %}
         <div class="col-12">
-            <table class="table table-bordered shadow">
-                <thead>
+            <table class="table pt-2" id="transcriptTable">
+                <thead class="table-success">
                   <tr>
                     <th scope="col">Gene</th>
                     <th scope="col">Transcript</th>
@@ -223,4 +231,13 @@
         {% endif %}
     </div>
 </div>
+{% endblock %}
+
+{% block script %}
+<script>
+    $(document).ready(function () {
+        new DataTable('#geneTable');
+        new DataTable('#transcriptTable');
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
- some template when certain model `ClinicalIndication` don't have `test_method` - show None in UI instead
- use dataTable in PanelGene and Transcript table in ClinicalIndication and Panel info page
- `gene.gene_id` instead of `gene.id` in ClinicalIndication info page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/34)
<!-- Reviewable:end -->
