### PR TITLE
IN-296 Web UI Pending Page Unclear

### DIFF
--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -240,6 +240,7 @@ def _make_panels_from_hgncs(
             moi_id=moi.id,
             mop_id=mop.id,
             penetrance_id=pen.id,
+            active=True,  # this should be True because it's linking HGNC panel to HGNC
             defaults={
                 "justification": unique_td_source,
             },

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -71,13 +71,16 @@ def _insert_gene(
                 if existing_panel_genes.exists():
                     for panel_gene in existing_panel_genes:
                         with transaction.atomic():
+                            panel_gene.active = False
                             panel_gene.pending = True
                             panel_gene.save()
 
                             PanelGeneHistory.objects.create(
                                 panel_gene_id=panel_gene.id,
                                 user="PanelApp",
-                                note=History.panel_gene_flagged(confidence_level),
+                                note=History.panel_gene_flagged_due_to_confidence(
+                                    confidence_level
+                                ),
                             )
                 continue  # if panel-gene doesn't exist in db then we don't care about this gene with confidence level < 3
             else:
@@ -128,6 +131,7 @@ def _insert_gene(
                 "moi_id": moi_instance.id,
                 "mop_id": mop_instance.id,
                 "penetrance_id": penetrance_instance.id,
+                "active": True,
             },
         )
 

--- a/requests_app/management/commands/generate.py
+++ b/requests_app/management/commands/generate.py
@@ -84,9 +84,10 @@ class Command(BaseCommand):
         """
         panel_genes = collections.defaultdict(list)
 
-        for row in PanelGene.objects.filter(panel_id__in=relevant_panels).values(
-            "gene_id__hgnc_id", "panel_id"
-        ):
+        for row in PanelGene.objects.filter(
+            panel_id__in=relevant_panels,
+            active=True,  # only fetch active panel-gene links
+        ).values("gene_id__hgnc_id", "panel_id"):
             panel_genes[row["panel_id"]].append(row["gene_id__hgnc_id"])
 
         return panel_genes

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -53,7 +53,13 @@ class History:
     ) -> str:
         return f"ClinicalIndicationPanel linking clinical indication {ci_id} to panel {panel_id} deactivated online {'by review' if review else ''}"
 
-    def panel_gene_flagged(
+    def panel_gene_flagged_due_to_confidence(
         confidence_level: str,
     ) -> str:
         return f"PanelGene flagged for manual review - confidence level dropped to {confidence_level}"
+
+    def panel_gene_approved(user) -> str:
+        return f"PanelGene approved by {user}"
+
+    def panel_gene_reverted(user) -> str:
+        return f"PanelGene reverted by {user}"

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -380,6 +380,11 @@ class PanelGene(models.Model):
         default=False,
     )
 
+    # needed for backward deactivation because deletion of panel-gene link is probably not the best
+    active = models.BooleanField(
+        verbose_name="Active",
+    )
+
     class Meta:
         db_table = "panel_gene"
 

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_gene.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_gene.py
@@ -301,6 +301,7 @@ class TestInsertGene_PreexistingGene_PreexistingPanelappPanelLink(TestCase):
             moi_id=self.moi.id,
             mop_id=self.mop.id,
             penetrance_id=self.penetrance.id,
+            active=True,
             justification="PanelApp",
         )
 
@@ -406,6 +407,7 @@ class TestAdditionOfGeneToExistingPanelGene(TestCase):
             moi_id=self.moi.id,
             mop_id=self.mop.id,
             penetrance_id=self.penetrance.id,
+            active=True,
             justification="PanelApp",
         )
 
@@ -537,6 +539,7 @@ class TestDropInPanelGeneConfidence(TestCase):
             moi_id=self.moi.id,
             mop_id=self.mop.id,
             penetrance_id=self.penetrance.id,
+            active=True,
             justification="PanelApp",
         )
 
@@ -547,6 +550,7 @@ class TestDropInPanelGeneConfidence(TestCase):
             moi_id=self.moi.id,
             mop_id=self.mop.id,
             penetrance_id=self.penetrance.id,
+            active=True,
             justification="PanelApp",
         )
 
@@ -630,7 +634,7 @@ class TestDropInPanelGeneConfidence(TestCase):
         errors += value_check_wrapper(
             PanelGeneHistory.objects.get(panel_gene_id=panel_gene_2.id).note,
             "history record note",
-            History.panel_gene_flagged(2),
+            History.panel_gene_flagged_due_to_confidence(2),
         )  # check that the history record is correct
 
         assert not errors, errors

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -52,7 +52,7 @@
                     <a class="nav-link" aria-current="page" href="{% url 'g2t' %}">G2t</a>
                 </div>
                 <div class="navbar-nav border-end border-2">
-                    <a class="nav-link" aria-current="page" href="{% url 'review' %}">Pending</a>
+                    <a class="nav-link" aria-current="page" href="{% url 'review' %}">Manual Review</a>
                 </div>
                 <div class="navbar-nav border-end border-2">
                     <a class="nav-link" aria-current="page" href="{% url 'genes' %}">Genes</a>

--- a/web/templates/web/history.html
+++ b/web/templates/web/history.html
@@ -10,7 +10,7 @@
     </div>
     <div class="row my-2">
         <div class="col"> <!-- form -->
-            <form action="{% url 'history' %}" method="post">
+            <form action="{% url 'history' %}" method="post" id="historyForm">
                 {% csrf_token %}
                 <select class="form-select" aria-label="default select example" name="history selection">
                     {% if 'clinical indications' in selected %}
@@ -60,7 +60,9 @@
                     </label>
                 </div>
                 {% endif %}
-                <button type="submit" class="btn btn-primary btn-sm mt-2">Submit</button>
+                <button type="submit" class="btn btn-primary btn-sm mt-2">Submit
+                    <span class="spinner-border spinner-border-sm ml-2 visually-hidden" aria-hidden="true"></span>
+                </button>
             </form> <!-- end form -->
         </div>
     </div>
@@ -167,6 +169,11 @@
 <script>
     $(document).ready(function () {
         new DataTable('#historyTable');
+
+        $('#historyForm').submit(function() {
+            $(this).find('button[type="submit"]').prop('disabled', true);
+            $(this).find('button[type="submit"]').find('.visually-hidden').removeClass('visually-hidden');
+        });
     });
 </script>
 {% endblock %}

--- a/web/templates/web/info/gene.html
+++ b/web/templates/web/info/gene.html
@@ -27,6 +27,9 @@
                 <div class="card-body">
                     <h5 class="text-break"><a href="{% url 'panel' panel.panel_id %}">{{ panel.panel_id__panel_name }}</a></h5>
                     <h6 class="text-muted">panel id in database: <span class="text-info">{{ panel.panel_id }}</span></h6>
+                    {% if not panel.active %}
+                    <span class="badge text-bg-warning">Link Inactive</span>
+                    {% endif %}
 
                     <ul class="list-group list-group-flush">
                         <li class="list-group-item">panelapp id: {{ panel.panel_id__external_id }}</li>

--- a/web/templates/web/info/panel.html
+++ b/web/templates/web/info/panel.html
@@ -172,6 +172,7 @@
                   <tr>
                     <th scope="col">HGNC ID</th>
                     <th scope="col">Gene Symbol</th>
+                    <th scope="col">Active</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -179,6 +180,11 @@
                     <tr>
                         <td><a href="{% url 'gene' pg.gene_id %}">{{ pg.gene_id__hgnc_id }}</a></td>
                         <td>{{ pg.gene_id__gene_symbol }}</td>
+                        {% if pg.active %}
+                        <td><span class="badge text-bg-success">Active</span></td>
+                        {% else %}
+                        <td><span class="badge text-bg-danger">Inactive</span></td>
+                        {% endif %}
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/web/templates/web/review/pending.html
+++ b/web/templates/web/review/pending.html
@@ -40,7 +40,14 @@
     <!-- Title -->
     <div class="row">
         <div class="col">
-            <div class="h3">Review</div>
+            <div class="h3">Manual Review</div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <div class="alert alert-warning" role="alert">
+                Changes to the database relationships in need of manual review.
+            </div>
         </div>
     </div>
     <!-- Panel Review -->
@@ -204,5 +211,54 @@
         </div>
     </div>
     <!-- Clinical Indication Panel Review End -->
+    <!-- Panel Gene Review -->
+    <div class="row">
+        <div class="col">
+            <h5>Panel Gene</h5>
+            {% if panel_gene %}
+            <table class="table table-bordered shadow">
+                <thead>
+                  <tr>
+                    <th scope="col">Panel</th>
+                    <th scope="col">Gene</th>
+                    <th scope="col">Reason</th>
+                    <th scope="col">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                {% for pg in panel_gene %}
+                    <tr>
+                        <td>{{ pg.panel_id__panel_name }}</td>
+                        <td>{{ pg.gene_id__hgnc_id }}</td>
+                        <td>
+                            <div class="d-flex justify-content-around">
+                                <!-- approving new ci-panel link -->
+                                <form action="{% url 'review' %}" method="POST">
+                                    {% csrf_token %}
+                                    <input type="text" class="form-control visually-hidden" name="pg_id" value="{{ pg.id }}">
+                                    <input type="text" class="form-control visually-hidden" name="action" value="approve_pg">
+                                    <button type="submit" class="btn btn-success btn-sm">Approve</button>
+                                </form>
+                                <!-- ignoring action on ci-panel link -->
+                                <form action="{% url 'review' %}" method="POST">
+                                    {% csrf_token %}
+                                    <input type="text" class="form-control visually-hidden" name="pg_id" value="{{ pg.id }}">
+                                    <input type="text" class="form-control visually-hidden" name="action" value="remove_pg">
+                                    <button type="submit" class="btn btn-danger btn-sm">Remove</button>
+                                </form>                                
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <div class="alert alert-primary" role="alert">
+                Nothing pending
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    <!-- Panel Gene Review End -->
 </div>
 {% endblock %}

--- a/web/templates/web/review/pending.html
+++ b/web/templates/web/review/pending.html
@@ -3,7 +3,9 @@
 {% block content %}
 <div class="container mb-5">
     <!-- Success notification -->
-    {% if action_cip or action_ci or action_panel %}
+    {% if action_cip or action_ci or action_panel or action_pg %}
+        <!-- Depending on what has been approved, show relevant notice -->
+        <!-- Clinical Indication Panel -->
         {% if action_cip %}
             {% if approve_bool %}
             <div class="alert alert-success" role="alert">
@@ -14,6 +16,7 @@
                 <a href="{% url 'clinical_indication' action_cip.clinical_indication_id %}">{{ action_cip.clinical_indication_id__r_code }} {{ action_cip.clinical_indication_id__name }}</a> to <a href="{% url 'panel' action_cip.panel_id %}">{{ action_cip.panel_id__panel_name }} v{{ action_cip.panel_id__panel_version }}</a> has been reverted!
             </div>
             {% endif %}
+        <!-- Clinical Indication -->
         {% elif action_ci %}
             {% if approve_bool %}
             <div class="alert alert-success" role="alert">
@@ -24,7 +27,8 @@
                 Clinical Indication has been removed!
             </div>
             {% endif %}
-        {% else %}
+        <!-- Panel -->
+        {% elif action_panel %}
             {% if approve_bool %}
             <div class="alert alert-success" role="alert">
                 <a href="{% url 'panel' action_panel.id %}">{{ action_panel.panel_name }}</a> has been approved!
@@ -34,6 +38,11 @@
                 Panel has been removed!
             </div>
             {% endif %}
+        <!-- Panel Gene -->
+        {% elif action_pg %}
+            <div class="alert alert-success" role="alert">
+                Link between <a href="{{ action_pg.panel_id }}">{{ action_pg.panel_id__panel_name }}</a> and <a href="{{ action_pg.gene_id }}">{{ action_pg.gene_id__hgnc_id }}</a> now set to active status: {{ action_pg.active}}!
+            </div>
         {% endif %}
     {% endif %}
     <!-- End notification -->
@@ -45,7 +54,7 @@
     </div>
     <div class="row">
         <div class="col">
-            <div class="alert alert-warning" role="alert">
+            <div class="alert alert-info" role="alert">
                 Changes to the database relationships in need of manual review.
             </div>
         </div>
@@ -222,14 +231,21 @@
                     <th scope="col">Panel</th>
                     <th scope="col">Gene</th>
                     <th scope="col">Reason</th>
+                    <th scope="col">Pending</th>
                     <th scope="col">Action</th>
                   </tr>
                 </thead>
                 <tbody>
                 {% for pg in panel_gene %}
                     <tr>
-                        <td>{{ pg.panel_id__panel_name }}</td>
-                        <td>{{ pg.gene_id__hgnc_id }}</td>
+                        <td class="text-break text-wrap" style="max-width: 17em;"><a href="{% url 'panel' pg.panel_id %}">{{ pg.panel_id__panel_name }}</a></td>
+                        <td><a href="{% url 'gene' pg.gene_id %}">{{ pg.gene_id__hgnc_id }}</a></td>
+                        <td>{{ pg.reason }}</td>
+                        {% if pg.active %}
+                        <td>Pending Activation</td>
+                        {% else %}
+                        <td>Pending Deactivation</td>
+                        {% endif %}
                         <td>
                             <div class="d-flex justify-content-around">
                                 <!-- approving new ci-panel link -->
@@ -243,8 +259,8 @@
                                 <form action="{% url 'review' %}" method="POST">
                                     {% csrf_token %}
                                     <input type="text" class="form-control visually-hidden" name="pg_id" value="{{ pg.id }}">
-                                    <input type="text" class="form-control visually-hidden" name="action" value="remove_pg">
-                                    <button type="submit" class="btn btn-danger btn-sm">Remove</button>
+                                    <input type="text" class="form-control visually-hidden" name="action" value="revert_pg">
+                                    <button type="submit" class="btn btn-warning btn-sm">Revert</button>
                                 </form>                                
                             </div>
                         </td>


### PR DESCRIPTION
# Changes
- added a new col in PanelGene model `active` & the field is compulsory. This means that other area where PanelGene is created will need this parameter when doing `PanelGene.create()` e.g. `insert_panel` and `insert_gene` function
- when generating genepanel file, only use PanelGene links that are `active` = True
- modification to PanelGene History record `panel_gene_flagged_due_to_confidence` because that's probably the only way PanelGene is going to get flagged
- added `panel_gene_approved` and `panel_gene_reverted` in History record template for when panel-gene link is approved or reverted for either activation or deactivation in Manual Review page
- renamed "Pending" page to "Manual Review" page
- `pending` PanelGene link now showing in "Manual Review" page
- PanelGene relationship in 'Panel' page now show their active status


# Unit Test
```
env) jason@Jasons-MBA eris % python manage.py test
Found 63 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
.Inserting test directory data into database...
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
Data insertion completed.
.Inserting test directory data into database...
...........None: No Panel record has panelapp ID 999
..........For panel Acute rhabdomyolyosis, skipping gene without HGNC ID: acyl-CoA dehydrogenase family member 9
..............................
----------------------------------------------------------------------
Ran 63 tests in 4.177s

OK
Destroying test database for alias 'default'...
```

<img width="1432" alt="Screenshot 2023-10-09 at 16 53 45" src="https://github.com/eastgenomics/eris/assets/60819172/33e7bbbe-4842-42ff-826f-cb64811683c0">
<img width="1435" alt="Screenshot 2023-10-09 at 16 54 02" src="https://github.com/eastgenomics/eris/assets/60819172/313d35c7-9d80-4020-938e-cd62551f3e62">
<img width="1397" alt="Screenshot 2023-10-09 at 16 54 26" src="https://github.com/eastgenomics/eris/assets/60819172/7c3f731e-8533-42f2-9e3b-442feb0dbcf1">
