### PR TITLE
Add superpanels

### DIFF
--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -190,7 +190,8 @@ def _get_td_version(filename: str) -> str | None:
         print(f"TD version not found in filename {filename}")
         return None
 
-def _check_td_version_valid(td_version, latest_db_version, force):
+def _check_td_version_valid(td_version: str, latest_db_version: str,
+                             force: bool) -> None:
     """
     Compares the current TD upload's version to the latest in the 
     database. Causes exceptions to raise if the current TD upload
@@ -254,7 +255,8 @@ def _retrieve_superpanel_from_pa_id(ci_code: str, pa_id: str) -> SuperPanel | No
     return panel_instance
 
 
-def _retrieve_unknown_metadata_records():
+def _retrieve_unknown_metadata_records() -> \
+    tuple[Confidence, ModeOfInheritance, ModeOfPathogenicity, Penetrance]:
     """
     Retrieve additional metadata records for PanelGene records
 
@@ -514,8 +516,9 @@ def _fetch_latest_td_version() -> str:
     return db_latest_td
 
 
-def _update_ci_panel_tables_with_new_ci(r_code, td_source, td_version, ci_instance,
-                               config_source):
+def _update_ci_panel_tables_with_new_ci(
+        r_code: str, td_source: str, td_version: str, ci_instance: 
+        ClinicalIndication, config_source: str) -> None:
     """
     New clinical indication - the old CI-panel and CI-superpanel entries with the
     same R code, will be set to 'pending = True'. The new CI will be linked to 
@@ -549,8 +552,9 @@ def _update_ci_panel_tables_with_new_ci(r_code, td_source, td_version, ci_instan
         new_clinical_indication_panel.config_source = config_source
         new_clinical_indication_panel.save()
 
-def _update_ci_superpanel_tables_with_new_ci(r_code, td_source, td_version, ci_instance,
-                               config_source):
+def _update_ci_superpanel_tables_with_new_ci(
+        r_code: str, td_source: str, td_version: str, ci_instance:
+        ClinicalIndication, config_source: str) -> None:
     """
     New clinical indication - the old CI-superpanel entries with the
     same R code, will be set to 'pending = True'. The new CI will be linked to 
@@ -582,8 +586,8 @@ def _update_ci_superpanel_tables_with_new_ci(r_code, td_source, td_version, ci_i
         new_clinical_indication_superpanel.config_source = config_source
         new_clinical_indication_superpanel.save()
 
-def _update_ci_panel_links(cip_instance, td_version, td_source,
-                           config_source):
+def _update_ci_panel_links(cip_instance: ClinicalIndicationPanel, td_version:
+                           str, td_source: str, config_source: str) -> None:
     """
     If CI-Panel already exists and the link is the same,
     just update the config source and td version (if different)
@@ -619,8 +623,9 @@ def _update_ci_panel_links(cip_instance, td_version, td_source,
 
         cip_instance.save()
 
-def _update_ci_superpanel_links(cip_instance, td_version, td_source,
-                           config_source):
+def _update_ci_superpanel_links(cip_instance: ClinicalIndicationSuperPanel,
+                                td_version: str, td_source: str,
+                                config_source: str) -> None:
     """
     If CI-SuperPanel already exists and the link is the same,
     just update the config source and td version (if different)
@@ -656,8 +661,12 @@ def _update_ci_superpanel_links(cip_instance, td_version, td_source,
 
         cip_instance.save()
 
-def _attempt_ci_panel_creation(ci_instance, panel_record, td_version,
-                               td_source, config_source):
+def _attempt_ci_panel_creation(ci_instance: ClinicalIndication, panel_record:
+                               Panel, td_version: str, td_source: str,
+                               config_source: str) -> \
+                                tuple[
+                                   ClinicalIndicationPanel, bool
+                                   ]:
     """
     Gets-or-creates a ClinicalIndicationPanel entry.
     If the entry is new, it will log history too.
@@ -685,8 +694,11 @@ def _attempt_ci_panel_creation(ci_instance, panel_record, td_version,
 
     return cip_instance, cip_created
 
-def _attempt_ci_superpanel_creation(ci_instance, superpanel_record, td_version,
-                               td_source, config_source):
+def _attempt_ci_superpanel_creation(ci_instance: ClinicalIndication,
+                                    superpanel_record: SuperPanel, td_version:
+                                    str, td_source: str, config_source:
+                                    str) -> tuple[ClinicalIndicationSuperPanel,
+                                                  bool]:
     """
     Gets-or-creates a ClinicalIndicationSuperPanel entry.
     If the entry is new, it will log history too.
@@ -714,7 +726,9 @@ def _attempt_ci_superpanel_creation(ci_instance, superpanel_record, td_version,
 
     return cip_instance, cip_created
 
-def _flag_panels_removed_from_test_directory(ci_instance, panels, td_source):
+def _flag_panels_removed_from_test_directory(ci_instance: ClinicalIndication,
+                                             panels: list, td_source: str) \
+                                                -> None:
     """
     For a clinical indication, finds any pre-existing links to Panels and
     checks that each Panel is still in the test directory.
@@ -748,7 +762,9 @@ def _flag_panels_removed_from_test_directory(ci_instance, panels, td_source):
                     user=td_source,
                 )
 
-def _flag_superpanels_removed_from_test_directory(ci_instance, panels, td_source):
+def _flag_superpanels_removed_from_test_directory(ci_instance: ClinicalIndication,
+                                                  panels: list, td_source: str) \
+                                                    -> None:
     """
     For a clinical indication, finds any pre-existing links to SuperPanels and
     checks that each SuperPanel is still in the test directory.

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -206,8 +206,8 @@ def _check_td_version_valid(td_version, latest_db_version, force):
             latest_db_version.td_version
         ):
             raise Exception(
-                f"TD version {td_version} lower than one in db {normalize_version(
-                    latest_db_version.td_version)}. Abdandoning import."
+                f"TD version {td_version} lower than one in db "
+                f"{normalize_version(latest_db_version.td_version)}. Abdandoning import."
             )
 
 def _retrieve_panel_from_pa_id(ci_code: str, pa_id: str) -> Panel | None:
@@ -885,8 +885,8 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
                         # No record exists of this panel/superpanel
                         # e.g. panel id 489 has been retired
                         print(
-                            f"{indication['code']}: No Panel or SuperPanel record 
-                            has panelapp ID {pa_id}"
+                            f"{indication['code']}: No Panel or SuperPanel record "
+                            f"has panelapp ID {pa_id}"
                         )
                         pass
 

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -67,7 +67,7 @@ def flag_clinical_indication_panel_for_review(
     This function is normally called when there is a new ci-panel link when seeding thus
     the old ci-panel link will be flagged to be deactivated / ignored
     while the new one will be created with pending `True`
-    
+
     :param: clinical_indication_panel [ClinicalIndicationPanel] which needs to be flagged for manual
     review, usually because something has changed in the test directory
     :param: user [str] - currently a string, may one day be a User object if we get
@@ -223,7 +223,7 @@ def _check_td_version_valid(
     database. Causes exceptions to raise if the current TD upload
     is for an old version of the test directory, relative to what's
     in Eris already. If everything is fine, does nothing.
-    
+
     :param: td_version [str], the TD version parsed from the user-uploaded
     test directory file
     :param: latest_db_version [str], the latest TD version found in the
@@ -611,7 +611,7 @@ def _update_ci_superpanel_tables_with_new_ci(
     New clinical indication - the old CI-superpanel entries with the
     same R code, will be set to 'pending = True'. The new CI will be linked to
     those panels, again with 'pending = True' to make it "provisional".
-    
+
     :param: r_code [str], the R code of the new clinical indication
     :param: td_source [str], the test directory's source
     :param: td_version [str], the test directory's version
@@ -747,7 +747,7 @@ def _attempt_ci_panel_creation(
     Gets-or-creates a ClinicalIndicationPanel entry.
     If the entry is new, it will log history too.
 
-    :param: ci_instance [ClinicalIndication], a clinical indication which 
+    :param: ci_instance [ClinicalIndication], a clinical indication which
     needs linking to a panel
     :param: panel_record [Panel], a panel which needs linking to a clinical
     indication
@@ -793,7 +793,7 @@ def _attempt_ci_superpanel_creation(
     Gets-or-creates a ClinicalIndicationSuperPanel entry.
     If the entry is new, it will log history too.
 
-    :param: ci_instance [ClinicalIndication], a clinical indication which 
+    :param: ci_instance [ClinicalIndication], a clinical indication which
     needs linking to a panel
     :param: panel_record [Panel], a panel which needs linking to a clinical
     indication

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -122,6 +122,37 @@ def provisionally_link_clinical_indication_to_panel(
     return ci_panel_instance
 
 
+def provisionally_link_clinical_indication_to_superpanel(
+    superpanel_id: int,
+    clinical_indication_id: int,
+    user: str,
+) -> ClinicalIndicationSuperPanel:
+    """
+    Link a CI and superpanel, but set the 'pending' field to True,
+    so that it shows for manual review by a user.
+    Additionally, create a history record.
+    Intended for use when you are making 'best guesses' for links based on
+    previous CI-SuperPanel links.
+    """
+    ci_superpanel_instance, created = ClinicalIndicationSuperPanel.objects.update_or_create(
+        clinical_indication_id=clinical_indication_id,
+        superpanel_id=superpanel_id,
+        defaults={
+            "current": True,
+            "pending": True,
+        },
+    )
+
+    if created:
+        ClinicalIndicationSuperPanelHistory.objects.create(
+            clinical_indication_superpanel_id=ci_superpanel_instance.id,
+            note=History.auto_created_clinical_indication_panel(),
+            user=user,
+        )
+
+    return ci_superpanel_instance
+
+
 def _get_td_version(filename: str) -> str | None:
     """
     Get TD version from filename.

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -327,7 +327,7 @@ def _make_panels_from_hgncs(
         if previous_ci_panels:  # in the case where there are old ci-panel
             for ci_panel in previous_ci_panels:
                 flag_clinical_indication_panel_for_review(
-                    ci_panel, td_source
+                    ci_panel, False, td_source
                 )  # flag for review
 
                 # linking old ci with new panel with pending = True
@@ -492,7 +492,7 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
             ):
                 # flag previous ci-panel link for review because a new ci is created
                 flag_clinical_indication_panel_for_review(
-                    clinical_indication_panel, td_source
+                    clinical_indication_panel, False, td_source
                 )
 
                 # linking new ci with old panel with pending = True

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -504,9 +504,9 @@ def _fetch_latest_td_version() -> str:
     if not panels_latest_td and not superpanels_latest_td:
         db_latest_td = None
     elif not panels_latest_td:
-        db_latest_td = sortable_version(superpanels_latest_td)
+        db_latest_td = sortable_version(superpanels_latest_td.td_version)
     elif not superpanels_latest_td:
-        db_latest_td = sortable_version(panels_latest_td)
+        db_latest_td = sortable_version(panels_latest_td.td_version)
     else:
         db_latest_td = max([sortable_version(panels_latest_td.td_version),
                             sortable_version(superpanels_latest_td.td_version)])
@@ -803,6 +803,7 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
 
     # fetch TD version from filename
     td_version: str = _get_td_version(td_source)
+    print(td_version)
     assert td_version, f"Cannot parse TD version {td_version}"
 
     # check the test directory upload isn't for an older version

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -819,7 +819,6 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
 
     # fetch TD version from filename
     td_version: str = _get_td_version(td_source)
-    print(td_version)
     assert td_version, f"Cannot parse TD version {td_version}"
 
     # check the test directory upload isn't for an older version

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -305,7 +305,7 @@ def _insert_data_into_db(panel: PanelClass, user: str) -> Panel:
             current=True,
         ):
             flag_clinical_indication_panel_for_review(
-                clinical_indication_panel, "PanelApp"
+                clinical_indication_panel, False, "PanelApp"
             )
 
             clinical_indication_id = clinical_indication_panel.clinical_indication_id
@@ -369,7 +369,7 @@ def _insert_superpanel_into_db(superpanel: SuperPanelClass, child_panels: list[P
             current=True
         ):
             flag_clinical_indication_panel_for_review(
-                clinical_indication_superpanel, "PanelApp"
+                clinical_indication_superpanel, False, "PanelApp"
             )
 
             clinical_indication_id = clinical_indication_superpanel.clinical_indication_id

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -316,8 +316,8 @@ def _insert_panel_data_into_db(panel: PanelClass, user: str) -> Panel:
     return panel_instance, created
 
 
-def _insert_superpanel_into_db(superpanel: SuperPanelClass, child_panels: list[Panel], 
-                               user: str) -> None:
+def _insert_superpanel_into_db(superpanel: SuperPanelClass, child_panels:\
+                               list[Panel], user: str) -> None:
     """
     Insert data from a parsed SuperPanel.
     This function differs slightly from the one for Panels because:
@@ -341,7 +341,7 @@ def _insert_superpanel_into_db(superpanel: SuperPanelClass, child_panels: list[P
             "test_directory": False,
         },
     )
-    
+
     if created:
         # make links between the SuperPanel and its child panels
         for child in child_panels:
@@ -353,10 +353,11 @@ def _insert_superpanel_into_db(superpanel: SuperPanelClass, child_panels: list[P
             
         # if there are previous SuperPanel(s) with similar external_id,
         # mark previous CI-SuperPanel links as needing review
-        for clinical_indication_superpanel in ClinicalIndicationSuperPanel.objects.filter(
-            superpanel__external_id=panel_external_id,
-            current=True
-        ):
+        for clinical_indication_superpanel in ClinicalIndicationSuperPanel.\
+            objects.filter(
+                superpanel__external_id=panel_external_id,
+                current=True
+                ):
             flag_clinical_indication_superpanel_for_review(
                 clinical_indication_superpanel, "PanelApp"
             )
@@ -367,9 +368,10 @@ def _insert_superpanel_into_db(superpanel: SuperPanelClass, child_panels: list[P
                 "PanelApp"
             )
 
-    # if the superpanel hasn't just been created: the SuperPanel is either brand new,
-    # or it has altered the constituent panels WITHOUT changing SuperPanel name or version - 
-    # this would only happen if there were issues at PanelApp
+    # if the superpanel hasn't just been created: the SuperPanel is either 
+    # brand new, or it has altered the constituent panels WITHOUT changing
+    # SuperPanel name or version - this would only happen if there were
+    # issues at PanelApp
     return superpanel, created
 
 
@@ -379,12 +381,13 @@ def panel_insert_controller(panels: list[PanelClass], superpanels: \
     Carries out coordination of panel creation - Panels and SuperPanels are
     handled differently in the database.
     """
-    # currently, only handle Panel/SuperPanel if the panel data is from PanelApp
+    # currently, only handle Panel/SuperPanel if the panel data is from 
+    # PanelApp
     for panel in panels:
         panel_instance, _ = _insert_panel_data_into_db(panel, user)
 
     for superpanel in superpanels:
-        child_panel_instances= []
+        child_panel_instances = []
         for panel in superpanel.child_panels:
             child_panel_instance, _ = \
                 _insert_panel_data_into_db(panel, user)

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -63,14 +63,6 @@ def _insert_gene(
             )
             continue
 
-        # NOTE: PanelApp API returns some really stupid genes and confidence levels attached to super panel
-        # e.g. panel external id 465 "Other rare neuromuscular disorders"
-        # it returns 3 of the same gene FLNC with the same hgnc-id HGNC:3756
-        # 2 with confidence level 3 and one with confidence level 2
-        # which make no sense at all. On their website, they only showed the two with confidence level 3 (both have same hgnc id)
-
-        # TODO: need a logic to deal with super panel showing duplicate genes but with different confidence level
-
         # there is only confidence level 0 1 2 3
         # and we only fetch confidence level 3
         try:

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -392,9 +392,9 @@ def panel_insert_controller(panels: list[PanelClass], superpanels: \
         panel_instance, _ = _insert_panel_data_into_db(panel, user)
 
     for superpanel in superpanels:
-        child_panels = []
+        child_panel_instances= []
         for panel in superpanel.child_panels:
             child_panel_instance, _ = \
                 _insert_panel_data_into_db(panel, user)
-            child_panels += child_panel_instance
-        _insert_superpanel_into_db(superpanel, child_panels, user)
+            child_panel_instances.append(child_panel_instance)
+        _insert_superpanel_into_db(superpanel, child_panel_instances, user)

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -268,6 +268,9 @@ def _insert_panel_data_into_db(panel: PanelClass, user: str) -> Panel:
     Controls creation and flagging of new and old CI-Panel links,
     where the Panel version has changed.
     Controls creation of genes and regions.
+
+    :param: panel [PanelClass], parsed panel input from the API
+    :param: user [str], the user initiating this change
     """
     panel_external_id: str = panel.id
     panel_name: str = panel.name
@@ -324,6 +327,12 @@ def _insert_superpanel_into_db(
     This function differs slightly from the one for Panels because:
     1. SuperPanelClass has a different structure from PanelClass.
     2. SuperPanels need linking to their child-panels.
+
+    :param: superpanel [SuperPanelClass], parsed panel input from the API
+    :param: child_panels [list[Panel]], the 'child' panels which make up
+    the SuperPanel. These are already added to the db, so they're a list
+    of database objects.
+    :param: user [str], the user initiating this
     """
     panel_external_id: str = superpanel.id
     panel_name: str = superpanel.name
@@ -380,6 +389,11 @@ def panel_insert_controller(
     """
     Carries out coordination of panel creation - Panels and SuperPanels are
     handled differently in the database.
+
+    :param: panels [list[PanelClass]], a list of parsed panel input from the API
+    :param: superpanels [list[SuperPanel]], a list of parsed superpanel
+    input from the API
+    :param: user [str], the user initiating this
     """
     # currently, only handle Panel/SuperPanel if the panel data is from
     # PanelApp

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -369,7 +369,7 @@ def _insert_superpanel_into_db(superpanel: SuperPanelClass, child_panels: list[P
             current=True
         ):
             flag_clinical_indication_panel_for_review(
-                clinical_indication_superpanel, False, "PanelApp"
+                clinical_indication_superpanel, True, "PanelApp"
             )
 
             clinical_indication_id = clinical_indication_superpanel.clinical_indication_id

--- a/requests_app/management/commands/generate.py
+++ b/requests_app/management/commands/generate.py
@@ -103,7 +103,6 @@ class Command(BaseCommand):
 
         return ci_panels, relevant_panels
 
-
     def _get_relevant_panel_genes(self, relevant_panels: list[int]) -> dict[int, str]:
         """
         Using a list of relevant panels,
@@ -119,8 +118,9 @@ class Command(BaseCommand):
 
         return panel_genes
 
-    def _get_relevant_superpanel_genes(self, relevant_superpanels: list[int]) \
-        -> dict[int, str]:
+    def _get_relevant_superpanel_genes(
+        self, relevant_superpanels: list[int]
+    ) -> dict[int, str]:
         """
         Using a list of relevant superpanels,
         first find the constituent panels,
@@ -131,17 +131,15 @@ class Command(BaseCommand):
         superpanel_genes = collections.defaultdict(list)
 
         for superpanel_id in relevant_superpanels:
-
             linked_panel_list = PanelSuperPanel.objects.filter(
                 superpanel__id=superpanel_id
             )
             for i in linked_panel_list:
-                genes = PanelGene.objects.filter(
-                    panel=i.panel
-                ).values("gene_id__hgnc_id", "panel_id")
+                genes = PanelGene.objects.filter(panel=i.panel).values(
+                    "gene_id__hgnc_id", "panel_id"
+                )
                 for x in genes:
-                    superpanel_genes[superpanel_id].append(
-                        x["gene_id__hgnc_id"])
+                    superpanel_genes[superpanel_id].append(x["gene_id__hgnc_id"])
 
         return superpanel_genes
 
@@ -181,8 +179,7 @@ class Command(BaseCommand):
         return results
 
     def _format_output_data_genesuperpanels(
-        self, ci_panels: dict[str, list], panel_genes: dict[int, str],
-        rnas: set
+        self, ci_panels: dict[str, list], panel_genes: dict[int, str], rnas: set
     ) -> list[tuple[str, str, str]]:
         """
         Format a list of results ready for writing out to file.
@@ -205,8 +202,7 @@ class Command(BaseCommand):
 
                     # process the panel version
                     panel_version: str = (
-                        normalize_version(panel_dict
-                                          ["superpanel__panel_version"])
+                        normalize_version(panel_dict["superpanel__panel_version"])
                         if panel_dict["superpanel__panel_version"]
                         else "1.0"
                     )
@@ -259,19 +255,17 @@ class Command(BaseCommand):
             )
 
         ci_panels, relevant_panels = self._get_relevant_ci_panels()
-        ci_superpanels, relevant_superpanels = \
-            self._get_relevant_ci_superpanels()
+        ci_superpanels, relevant_superpanels = self._get_relevant_ci_superpanels()
 
         panel_genes = self._get_relevant_panel_genes(relevant_panels)
-        superpanel_genes = self._get_relevant_superpanel_genes(
-            relevant_superpanels)
+        superpanel_genes = self._get_relevant_superpanel_genes(relevant_superpanels)
 
-        panel_results = self._format_output_data_genepanels(ci_panels,\
-                                                            panel_genes, rnas)
+        panel_results = self._format_output_data_genepanels(
+            ci_panels, panel_genes, rnas
+        )
         superpanel_results = self._format_output_data_genesuperpanels(
-            ci_superpanels,
-            superpanel_genes,
-            rnas)
+            ci_superpanels, superpanel_genes, rnas
+        )
 
         results = panel_results + superpanel_results
 

--- a/requests_app/management/commands/generate.py
+++ b/requests_app/management/commands/generate.py
@@ -55,11 +55,15 @@ class Command(BaseCommand):
 
         return True
 
-    def _get_relevant_ci_panels(self) -> tuple[dict[str, list], list]:
+    def _get_relevant_ci_panels(self) -> tuple[dict[str, list], set]:
         """
         Retrieve relevant panels and CI-panels from the database
         These will be output in the final file.
         Returns CI panels and a list of relevant panels.
+
+        :return: ci_panels, a dict containing R codes as keys, with lists
+        of clinical indication-panel information provided as keys
+        :return: relevant_panels [set], a set of relevant panel IDs
         """
         relevant_panels = set()
 
@@ -84,6 +88,10 @@ class Command(BaseCommand):
         Retrieve relevant superpanels and CI-superpanels from the database
         These will be output in the final file.
         Returns CI superpanels and a list of relevant superpanels.
+        
+        :return: ci_superpanels, a dict containing R codes as keys, with lists
+        of clinical indication-superpanel information provided as keys
+        :return: relevant_panels [set], a set of relevant superpanel IDs
         """
         relevant_panels = set()
 
@@ -107,6 +115,11 @@ class Command(BaseCommand):
         """
         Using a list of relevant panels,
         retrieve the genes from those panels from the PanelGene database.
+
+        :param: relevant_panels [list[int]], a set of IDs of Panel objects
+        which will be used to retrieve those panels' genes from the db
+        :returns: panel_genes, a dict containing panel ID as keys and
+        gene information in the values
         """
         panel_genes = collections.defaultdict(list)
 
@@ -127,6 +140,11 @@ class Command(BaseCommand):
         then retrieve the genes from those panels from the PanelGene database.
         Returns a dict where the key is the superpanel's ID and the values are
         lists of genes.
+
+        :param: relevant_panels [list[int]], a set of IDs of SuperPanel objects
+        which will be used to retrieve constituent panels' genes from the db
+        :returns: superpanel_genes, a dict containing superpanel ID as keys, and
+        gene information for the child-panels in the values
         """
         superpanel_genes = collections.defaultdict(list)
 
@@ -149,6 +167,13 @@ class Command(BaseCommand):
         """
         Format a list of results ready for writing out to file.
         Sort the results before returning them.
+
+        :param: ci_panels, a dict linking clinical indications to panels
+        :param: panel_genes, a dict linking genes to panel IDs
+        :param: rnas, a set of RNAs parsed from HGNC information
+
+        :return: a list-of-lists. Each sublist contains a clinical indication,
+        panel name, and panel version
         """
         results = []
         for r_code, panel_list in ci_panels.items():
@@ -184,6 +209,13 @@ class Command(BaseCommand):
         """
         Format a list of results ready for writing out to file.
         Sort the results before returning them.
+
+        :param: ci_panels, a dict linking clinical indications to superpanels
+        :param: panel_genes, a dict linking genes to superpanel IDs
+        :param: rnas, a set of RNAs parsed from HGNC information
+
+        :return: a list-of-lists. Each sublist contains a clinical indication,
+        superpanel name, and superpanel version
         """
         results = []
         for r_code, panel_list in ci_panels.items():

--- a/requests_app/management/commands/generate.py
+++ b/requests_app/management/commands/generate.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
         Retrieve relevant superpanels and CI-superpanels from the database
         These will be output in the final file.
         Returns CI superpanels and a list of relevant superpanels.
-        
+
         :return: ci_superpanels, a dict containing R codes as keys, with lists
         of clinical indication-superpanel information provided as keys
         :return: relevant_panels [set], a set of relevant superpanel IDs

--- a/requests_app/management/commands/generate.py
+++ b/requests_app/management/commands/generate.py
@@ -253,8 +253,6 @@ class Command(BaseCommand):
                 "Please resolve these through the review platform and try again."
             )
 
-        #TODO: work out how to assemble super_panel data, and output it 
-        # in a way which looks OK in a TSV
         ci_panels, relevant_panels = self._get_relevant_ci_panels()
         ci_superpanels, relevant_superpanels = self._get_relevant_ci_superpanels()
 

--- a/requests_app/management/commands/panelapp.py
+++ b/requests_app/management/commands/panelapp.py
@@ -42,20 +42,20 @@ class SuperPanelClass:
 
         self.child_panels = self.create_component_panels(self.genes, self.regions)
 
-    def create_component_panels(genes, regions):
+    def create_component_panels(self, genes, regions):
         """
         Parse out component-panels from the API call.
         In a normal panel, the genes and regions are nested under the panel's overall info.
         But for superpanels, we find the panels by looking in 'panel' under each 
         constituent gene or region, so we need to reorder everything in parsing.
         """
-        component_panels = []
+        panels = []
 
         for gene in genes:
             parent_panel = gene["panel"]
             panel_id = parent_panel["id"]
             # fetch this Panel if its in the panel-list already, otherwise, make it
-            component_panel = next((x for x in component_panels if x.id == panel_id), None)
+            component_panel = next((x for x in panels if x.id == panel_id), None)
             if component_panel:
                 # append gene to the list associated with this panel
                 component_panel.genes.append(gene)
@@ -69,14 +69,16 @@ class SuperPanelClass:
                 component_panel.panel_source = "PanelApp"
                 # add this gene to the panel
                 component_panel.genes.append(gene)
+                panels.append(component_panel)
 
         for region in regions:
-            parent_panel = gene["region"]
-            panel_id = parent_panel["id"]
+            parent_panel = region["panel"]
+            panel_id = parent_panel["id"] 
+            #TODO: how does this handle region(s) duplicated from multiple panels
             # fetch this Panel if its in the panel-list already, otherwise, make it
-            component_panel = next((x for x in component_panels if x.id == panel_id), None)
+            component_panel = next((x for x in panels if x.id == panel_id), None)
             if component_panel:
-                # append gene to the list associated with this panel
+                # append region to the list associated with this panel
                 component_panel.regions.append(region)
             else:
                 # create panel and append region info to it
@@ -84,12 +86,13 @@ class SuperPanelClass:
                 component_panel.id = panel_id
                 component_panel.name = parent_panel["name"]
                 component_panel.version = parent_panel["version"]
+                
                 # currently only use SuperPanelClass for PanelApp
                 component_panel.panel_source = "PanelApp"
                 # add this region to the panel
                 component_panel.regions.append(region)
-
-        return component_panels
+                panels.append(component_panel)
+        return panels
 
 
 def _get_all_panel(signed_off: bool = True) -> list[dict]:

--- a/requests_app/management/commands/panelapp.py
+++ b/requests_app/management/commands/panelapp.py
@@ -146,7 +146,7 @@ def get_panel(panel_num: int, version: float = None) -> \
     if response.status_code != 200:
         return None
 
-    data = json.loads(response)
+    data = response.json()
     for i in data["types"]:
         if i["name"] == "Super Panel":
             return SuperPanelClass(**response.json()), True

--- a/requests_app/management/commands/panelapp.py
+++ b/requests_app/management/commands/panelapp.py
@@ -40,8 +40,7 @@ class SuperPanelClass:
         self.types: list[dict] = []
         [setattr(self, key, a[key]) for key in a]
 
-        self.child_panels = self.create_component_panels(self.genes,
-                                                         self.regions)
+        self.child_panels = self.create_component_panels(self.genes, self.regions)
 
     def create_component_panels(self, genes, regions):
         """
@@ -59,8 +58,7 @@ class SuperPanelClass:
             panel_id = parent_panel["id"]
             # fetch this Panel if its in the panel-list already, otherwise,
             # make it
-            component_panel = next((x for x in panels if x.id == panel_id),
-                                   None)
+            component_panel = next((x for x in panels if x.id == panel_id), None)
             if component_panel:
                 # append gene to the list associated with this panel
                 component_panel.genes.append(gene)
@@ -78,13 +76,12 @@ class SuperPanelClass:
 
         for region in regions:
             parent_panel = region["panel"]
-            panel_id = parent_panel["id"] 
-            #TODO: how does this handle region(s) duplicated from multiple
+            panel_id = parent_panel["id"]
+            # TODO: how does this handle region(s) duplicated from multiple
             # panels?
             # fetch this Panel if its in the panel-list already, otherwise,
             # make it
-            component_panel = next((x for x in panels if x.id == panel_id),
-                                   None)
+            component_panel = next((x for x in panels if x.id == panel_id), None)
             if component_panel:
                 # append region to the list associated with this panel
                 component_panel.regions.append(region)
@@ -148,8 +145,9 @@ def _check_superpanel_status(response: requests.Response) -> bool:
     return is_superpanel
 
 
-def get_panel(panel_num: int, version: float = None) -> \
-    tuple[PanelClass | SuperPanelClass, bool]:
+def get_panel(
+    panel_num: int, version: float = None
+) -> tuple[PanelClass | SuperPanelClass, bool]:
     """
     Function to get individual panel and panel version
 
@@ -195,8 +193,7 @@ def fetch_all_panels() -> tuple[list[PanelClass], list[SuperPanelClass]]:
         panel_version = panel.get("version")
 
         # fetching specific signed-off version
-        panel_data, is_superpanel = \
-            get_panel(panel_id, panel_version)
+        panel_data, is_superpanel = get_panel(panel_id, panel_version)
 
         if panel_data:
             panel_data.panel_source = "PanelApp"

--- a/requests_app/management/commands/panelapp.py
+++ b/requests_app/management/commands/panelapp.py
@@ -7,7 +7,7 @@ from panel_requests.settings import PANELAPP_API_URL
 class PanelClass:
     """
     Class for panel data. Default population is by greedy ingestion of all
-    attributes from PanelApp API. However, may also be populated by 
+    attributes from PanelApp API. However, may also be populated by
     SuperPanelClass.
     """
 
@@ -40,22 +40,27 @@ class SuperPanelClass:
         self.types: list[dict] = []
         [setattr(self, key, a[key]) for key in a]
 
-        self.child_panels = self.create_component_panels(self.genes, self.regions)
+        self.child_panels = self.create_component_panels(self.genes,
+                                                         self.regions)
 
     def create_component_panels(self, genes, regions):
         """
         Parse out component-panels from the API call.
-        In a normal panel, the genes and regions are nested under the panel's overall info.
-        But for superpanels, we find the panels by looking in 'panel' under each 
-        constituent gene or region, so we need to reorder everything in parsing.
+        In a normal panel, the genes and regions are nested under the panel's
+        overall info.
+        But for superpanels, we find the panels by looking in 'panel' under
+        each constituent gene or region, so we need to reorder everything
+        in parsing.
         """
         panels = []
 
         for gene in genes:
             parent_panel = gene["panel"]
             panel_id = parent_panel["id"]
-            # fetch this Panel if its in the panel-list already, otherwise, make it
-            component_panel = next((x for x in panels if x.id == panel_id), None)
+            # fetch this Panel if its in the panel-list already, otherwise,
+            # make it
+            component_panel = next((x for x in panels if x.id == panel_id),
+                                   None)
             if component_panel:
                 # append gene to the list associated with this panel
                 component_panel.genes.append(gene)
@@ -74,9 +79,12 @@ class SuperPanelClass:
         for region in regions:
             parent_panel = region["panel"]
             panel_id = parent_panel["id"] 
-            #TODO: how does this handle region(s) duplicated from multiple panels
-            # fetch this Panel if its in the panel-list already, otherwise, make it
-            component_panel = next((x for x in panels if x.id == panel_id), None)
+            #TODO: how does this handle region(s) duplicated from multiple
+            # panels?
+            # fetch this Panel if its in the panel-list already, otherwise,
+            # make it
+            component_panel = next((x for x in panels if x.id == panel_id),
+                                   None)
             if component_panel:
                 # append region to the list associated with this panel
                 component_panel.regions.append(region)
@@ -86,7 +94,7 @@ class SuperPanelClass:
                 component_panel.id = panel_id
                 component_panel.name = parent_panel["name"]
                 component_panel.version = parent_panel["version"]
-                
+
                 # currently only use SuperPanelClass for PanelApp
                 component_panel.panel_source = "PanelApp"
                 # add this region to the panel
@@ -136,7 +144,7 @@ def _check_superpanel_status(response: requests.Response) -> bool:
     for i in data["types"]:
         if i["name"] == "Super Panel":
             is_superpanel = True
-    
+
     return is_superpanel
 
 

--- a/requests_app/management/commands/panelapp.py
+++ b/requests_app/management/commands/panelapp.py
@@ -16,7 +16,7 @@ class PanelClass:
         self.panel_source: str = None
         self.genes: list[dict] = []
         self.regions: list[dict] = []
-
+        self.types: list[dict] = []
         [setattr(self, key, a[key]) for key in a]
 
 

--- a/requests_app/management/commands/panelapp.py
+++ b/requests_app/management/commands/panelapp.py
@@ -151,7 +151,7 @@ def get_panel(panel_num: int, version: float = None) -> \
         if i["name"] == "Super Panel":
             return SuperPanelClass(**response.json()), True
 
-    return PanelClass(**response.json()), False
+    return PanelClass(**response.json()), False #TODO: check this return
 
 
 def fetch_all_panels() -> tuple[list[PanelClass], list[SuperPanelClass]]:

--- a/requests_app/management/commands/panelapp.py
+++ b/requests_app/management/commands/panelapp.py
@@ -121,7 +121,8 @@ def _get_all_panel(signed_off: bool = True) -> list[dict]:
         response = requests.get(panelapp_url)
 
         if response.status_code != 200:
-            break
+            print(f"Aborting because API returned a non-200 exit code: {response.status_code}")
+            exit(1)
 
         data = response.json()
         all_panels += data["results"]  # append to all_panels
@@ -165,7 +166,8 @@ def get_panel(
     response = requests.get(panel_url)
 
     if response.status_code != 200:
-        return None
+        print(f"Aborting because API returned a non-200 exit code: {response.status_code}")
+        exit(1)
 
     is_superpanel = _check_superpanel_status(response)
 
@@ -194,7 +196,7 @@ def fetch_all_panels() -> tuple[list[PanelClass], list[SuperPanelClass]]:
 
         # fetching specific signed-off version
         panel_data, is_superpanel = get_panel(panel_id, panel_version)
-
+        
         if panel_data:
             panel_data.panel_source = "PanelApp"
             if is_superpanel:

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -159,17 +159,20 @@ class Command(BaseCommand):
                     )
 
                 # parse data from requested current PanelApp panels
-                panel, superpanel = get_panel(panel_id, panel_version)
+                panel_data, is_superpanel = get_panel(panel_id, panel_version)
 
-                if not panel or superpanel:
+                if not panel_data:
                     print(
                         f"Fetching panel id: {panel_id} version: {panel_version} failed"
                     )
                     raise ValueError("Panel specified does not exist")
-                panel.panel_source = "PanelApp"  # manual addition of source
+                panel_data.panel_source = "PanelApp"  # manual addition of source
 
-                panels = [panel]
-                superpanels = [superpanel]
+                if is_superpanel:
+                    superpanels = [panel_data]
+                else:
+                    panels = [panel_data]
+                
 
             if not test_mode:
                 # not printing amounts because there are some duplicates now,

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -166,7 +166,7 @@ class Command(BaseCommand):
                         f"Fetching panel id: {panel_id} version: {panel_version} failed"
                     )
                     raise ValueError("Panel specified does not exist")
-                panel_data.panel_source = "PanelApp" #manual addition of source
+                panel_data.panel_source = "PanelApp"  # manual addition of source
 
                 if is_superpanel:
                     superpanels = [panel_data]

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -172,10 +172,12 @@ class Command(BaseCommand):
                 superpanels = [superpanel]
 
             if not test_mode:
-                print(f"Importing {len(panels)} panels into database...")
+                # not printing amounts because there are some duplicates now,
+                # due to how superpanels work
+                print(f"Importing panels into database...")
 
                 # insert panel data into database
-                panel_insert_controller(panels, superpanels)
+                panel_insert_controller(panels, superpanels, user)
 
                 print("Done.")
 

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -166,13 +166,12 @@ class Command(BaseCommand):
                         f"Fetching panel id: {panel_id} version: {panel_version} failed"
                     )
                     raise ValueError("Panel specified does not exist")
-                panel_data.panel_source = "PanelApp"  # manual addition of source
+                panel_data.panel_source = "PanelApp" #manual addition of source
 
                 if is_superpanel:
                     superpanels = [panel_data]
                 else:
                     panels = [panel_data]
-                
 
             if not test_mode:
                 # not printing amounts because there are some duplicates now,

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -158,7 +158,6 @@ class Command(BaseCommand):
                         f"Getting panel id {panel_id} / panel version {panel_version}"
                     )
 
-                # TODO: handle superpanels
                 # parse data from requested current PanelApp panels
                 panel, superpanel = get_panel(panel_id, panel_version)
 

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -128,7 +128,6 @@ class PanelSuperPanel(models.Model):
     Defines links between SuperPanels and their constituent Panels.
     Necessary because a SuperPanel can contain any number of panels, 
     and a Panel could possibly be in multiple SuperPanels.
-    Old links aren't deleted, but are marked Inactive
     """
     panel = models.ForeignKey(
         Panel,
@@ -140,15 +139,6 @@ class PanelSuperPanel(models.Model):
         SuperPanel,
         verbose_name="superpanel",
         on_delete=models.PROTECT
-    )
-
-    # active status
-    active = models.BooleanField(verbose_name="latest association")
-
-    pending = models.BooleanField(
-        verbose_name="pending review",
-        null=True,
-        default=False,
     )
 
     class Meta:

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -236,6 +236,70 @@ class ClinicalIndicationPanel(models.Model):
         return str(self.id)
 
 
+class ClinicalIndicationSuperPanel(models.Model):
+    """
+    Defines an association between a clinical indication and a superpanel
+    and when that association is made
+
+    e.g. Normally when importing new Test Directory
+    a new association between Clinical Indication and new version of
+    Panel might be made
+    """
+
+    # metadata
+    config_source = models.TextField(
+        verbose_name="config source",
+        max_length=255,
+        null=True,
+    )
+
+    td_version = models.CharField(
+        verbose_name="test directory version",
+        max_length=255,
+        null=True,
+    )
+
+    # creation date
+    created = models.DateTimeField(
+        verbose_name="created",
+        auto_now_add=True,
+    )
+
+    last_updated = models.DateTimeField(
+        verbose_name="last updated",
+        null=True,
+        auto_now=True,
+    )
+
+    # foreign keys
+    clinical_indication = models.ForeignKey(
+        ClinicalIndication,
+        verbose_name="clinical indication id",
+        on_delete=models.PROTECT,
+    )  # required
+
+    panel = models.ForeignKey(
+        SuperPanel,
+        verbose_name="superpanel id",
+        on_delete=models.PROTECT,
+    )  # required
+
+    # active status
+    current = models.BooleanField(verbose_name="latest association")
+
+    pending = models.BooleanField(
+        verbose_name="pending review",
+        null=True,
+        default=False,
+    )
+
+    class Meta:
+        db_table = "clinical_indication_superpanel"
+
+    def __str__(self):
+        return str(self.id)
+
+
 class ClinicalIndicationPanelHistory(models.Model):
     # foreign key
     clinical_indication_panel = models.ForeignKey(
@@ -266,6 +330,39 @@ class ClinicalIndicationPanelHistory(models.Model):
 
     def __str__(self):
         return str(self.id)
+
+
+class ClinicalIndicationSuperPanelHistory(models.Model):
+    # foreign key
+    clinical_indication_superpanel = models.ForeignKey(
+        ClinicalIndicationSuperPanel,
+        on_delete=models.PROTECT,
+        verbose_name="clinical indication superpanel id",
+    )
+
+    # creation date
+    created = models.DateTimeField(
+        verbose_name="created",
+        auto_now_add=True,
+    )
+
+    note = models.CharField(
+        verbose_name="note",
+        max_length=255,
+    )
+
+    user = models.CharField(
+        verbose_name="user",
+        max_length=255,
+        null=True,
+    )
+
+    class Meta:
+        db_table = "clinical_indication_superpanel_history"
+
+    def __str__(self):
+        return str(self.id)
+
 
 
 class ClinicalIndicationTestMethodHistory(models.Model):

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -130,9 +130,17 @@ class PanelSuperPanel(models.Model):
     and a Panel could possibly be in multiple SuperPanels.
     Old links aren't deleted, but are marked Inactive
     """
-    panel = models.ForeignKey()
+    panel = models.ForeignKey(
+        Panel,
+        verbose_name="component panel",
+        on_delete=models.PROTECT
+    )
 
-    superpanel = models.ForeignKey()
+    superpanel = models.ForeignKey(
+        SuperPanel,
+        verbose_name="superpanel",
+        on_delete=models.PROTECT
+    )
 
     # active status
     active = models.BooleanField(verbose_name="latest association")

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -60,6 +60,84 @@ class Panel(models.Model):
         return str(self.id)
 
 
+class SuperPanel(models.Model):
+    """
+    Defines Superpanels - these are panels made of child panels added together.
+    Otherwise very similar to Panels.
+    """
+    # this is the PanelApp Panel id itself
+    external_id = models.CharField(
+        verbose_name="external panel id", max_length=255, null=True
+    )
+
+    # metadata
+    panel_name = models.CharField(verbose_name="Superpanel Name", max_length=255)
+
+    panel_source = models.CharField(
+        verbose_name="superpanel source",
+        max_length=255,
+    )
+
+    panel_version = models.CharField(
+        verbose_name="superpanel version",
+        max_length=255,
+        null=True,
+    )
+
+    # reference genome
+    grch37 = models.BooleanField(verbose_name="grch37", default=True)
+    grch38 = models.BooleanField(verbose_name="grch38", default=True)
+
+    # whether panel is created from test directory
+    test_directory = models.BooleanField(
+        verbose_name="created from test directory",
+        null=True,
+        default=False,
+    )
+
+    # whether panel is customized
+    custom = models.BooleanField(
+        verbose_name="custom superpanel",
+        null=True,
+        default=False,
+    )
+
+    # creation date
+    created = models.DateTimeField(
+        verbose_name="created",
+        auto_now_add=True,
+    )
+
+    pending = models.BooleanField(
+        verbose_name="pending activation",
+        null=True,
+        default=False,
+    )
+
+    class Meta:
+        db_table = "superpanel"
+
+    def __str__(self):
+        return str(self.id)
+
+
+class PanelSuperPanel(models.Model):
+    """
+    Defines links between SuperPanels and their constituent Panels.
+    Necessary because a SuperPanel can contain any number of panels, 
+    and a Panel could possibly be in multiple SuperPanels.
+    """
+    panel = models.ForeignKey()
+
+    superpanel = models.ForeignKey()
+
+    class Meta:
+        db_table = "panel_superpanel"
+
+    def __str__(self):
+        return str(self.id)
+
+
 class ClinicalIndication(models.Model):
     """Defines a single clinical indication"""
 

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -72,7 +72,8 @@ class SuperPanel(models.Model):
     )
 
     # metadata
-    panel_name = models.CharField(verbose_name="Superpanel Name", max_length=255)
+    panel_name = models.CharField(verbose_name="Superpanel Name",
+                                  max_length=255)
 
     panel_source = models.CharField(
         verbose_name="superpanel source",
@@ -126,7 +127,7 @@ class SuperPanel(models.Model):
 class PanelSuperPanel(models.Model):
     """
     Defines links between SuperPanels and their constituent Panels.
-    Necessary because a SuperPanel can contain any number of panels, 
+    Necessary because a SuperPanel can contain any number of panels,
     and a Panel could possibly be in multiple SuperPanels.
     """
     panel = models.ForeignKey(

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -47,6 +47,7 @@ class Panel(models.Model):
         auto_now_add=True,
     )
 
+    # whether a panel is waiting for human review
     pending = models.BooleanField(
         verbose_name="pending activation",
         null=True,
@@ -108,6 +109,7 @@ class SuperPanel(models.Model):
         auto_now_add=True,
     )
 
+    # whether a panel is waiting for human review
     pending = models.BooleanField(
         verbose_name="pending activation",
         null=True,
@@ -126,10 +128,20 @@ class PanelSuperPanel(models.Model):
     Defines links between SuperPanels and their constituent Panels.
     Necessary because a SuperPanel can contain any number of panels, 
     and a Panel could possibly be in multiple SuperPanels.
+    Old links aren't deleted, but are marked Inactive
     """
     panel = models.ForeignKey()
 
     superpanel = models.ForeignKey()
+
+    # active status
+    active = models.BooleanField(verbose_name="latest association")
+
+    pending = models.BooleanField(
+        verbose_name="pending review",
+        null=True,
+        default=False,
+    )
 
     class Meta:
         db_table = "panel_superpanel"

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -66,14 +66,14 @@ class SuperPanel(models.Model):
     Defines Superpanels - these are panels made of child panels added together.
     Otherwise very similar to Panels.
     """
+
     # this is the PanelApp Panel id itself
     external_id = models.CharField(
         verbose_name="external panel id", max_length=255, null=True
     )
 
     # metadata
-    panel_name = models.CharField(verbose_name="Superpanel Name",
-                                  max_length=255)
+    panel_name = models.CharField(verbose_name="Superpanel Name", max_length=255)
 
     panel_source = models.CharField(
         verbose_name="superpanel source",
@@ -130,16 +130,13 @@ class PanelSuperPanel(models.Model):
     Necessary because a SuperPanel can contain any number of panels,
     and a Panel could possibly be in multiple SuperPanels.
     """
+
     panel = models.ForeignKey(
-        Panel,
-        verbose_name="component panel",
-        on_delete=models.PROTECT
+        Panel, verbose_name="component panel", on_delete=models.PROTECT
     )
 
     superpanel = models.ForeignKey(
-        SuperPanel,
-        verbose_name="superpanel",
-        on_delete=models.PROTECT
+        SuperPanel, verbose_name="superpanel", on_delete=models.PROTECT
     )
 
     class Meta:
@@ -373,7 +370,6 @@ class ClinicalIndicationSuperPanelHistory(models.Model):
 
     def __str__(self):
         return str(self.id)
-
 
 
 class ClinicalIndicationTestMethodHistory(models.Model):

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -294,13 +294,13 @@ class ClinicalIndicationSuperPanel(models.Model):
     # foreign keys
     clinical_indication = models.ForeignKey(
         ClinicalIndication,
-        verbose_name="clinical indication id",
+        verbose_name="clinical indication",
         on_delete=models.PROTECT,
     )  # required
 
-    panel = models.ForeignKey(
+    superpanel = models.ForeignKey(
         SuperPanel,
-        verbose_name="superpanel id",
+        verbose_name="superpanel",
         on_delete=models.PROTECT,
     )  # required
 

--- a/testing_files/panelapp_api_mocks/superpanel_api_example_gene_region_same_panel.json
+++ b/testing_files/panelapp_api_mocks/superpanel_api_example_gene_region_same_panel.json
@@ -1,0 +1,210 @@
+{
+    "id": 465,
+    "hash_id": null,
+    "name": "Other rare neuromuscular disorders",
+    "disease_group": "",
+    "disease_sub_group": "",
+    "status": "public",
+    "version": "19.156",
+    "version_created": "2023-10-16T16:58:09.745398Z",
+    "relevant_disorders": [
+      "Neuromuscular disorders",
+      "R381"
+    ],
+    "stats": {
+      "number_of_genes": 453,
+      "number_of_strs": 7,
+      "number_of_regions": 8
+    },
+    "types": [
+      {
+        "name": "GMS Rare Disease Virtual",
+        "slug": "gms-rare-disease-virtual",
+        "description": "This is a panel for the Genomic Medicine Service for an exome/genome/panel based test that requires a virtual gene panel for rare disease in the Test Directory."
+      },
+      {
+        "name": "Super Panel",
+        "slug": "superpanel",
+        "description": "Superpanel"
+      },
+      {
+        "name": "GMS signed-off",
+        "slug": "gms-signed-off",
+        "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+      }
+    ],
+    "genes": [
+      {
+        "gene_data": {
+          "alias": [
+            "AC",
+            "PHP32",
+            "FLJ21558",
+            "ACDase"
+          ],
+          "biotype": "protein_coding",
+          "hgnc_id": "HGNC:735",
+          "gene_name": "N-acylsphingosine amidohydrolase 1",
+          "omim_gene": [
+            "613468"
+          ],
+          "alias_name": [
+            "acylsphingosine deacylase",
+            "acid ceramidase"
+          ],
+          "gene_symbol": "ASAH1",
+          "hgnc_symbol": "ASAH1",
+          "hgnc_release": "2017-11-03T00:00:00",
+          "ensembl_genes": {
+            "GRch37": {
+              "82": {
+                "location": "8:17913934-17942494",
+                "ensembl_id": "ENSG00000104763"
+              }
+            },
+            "GRch38": {
+              "90": {
+                "location": "8:18055992-18084998",
+                "ensembl_id": "ENSG00000104763"
+              }
+            }
+          },
+          "hgnc_date_symbol_changed": "2002-09-13"
+        },
+        "entity_type": "gene",
+        "entity_name": "ASAH1",
+        "confidence_level": "3",
+        "penetrance": "Complete",
+        "mode_of_pathogenicity": "",
+        "publications": [
+          "22703880"
+        ],
+        "evidence": [
+          "Expert Review Green",
+          "Radboud University Medical Center, Nijmegen"
+        ],
+        "phenotypes": [
+          "Spinal muscular atrophy with progressive myoclonic epilepsy, OMIM:159950"
+        ],
+        "mode_of_inheritance": "BIALLELIC, autosomal or pseudoautosomal",
+        "tags": [],
+        "panel": {
+          "id": 79,
+          "hash_id": "5541ef3dbb5a160c33b964e0",
+          "name": "Paediatric motor neuronopathies",
+          "disease_group": "Neurology and neurodevelopmental disorders",
+          "disease_sub_group": "Motor and Sensory Disorders of the PNS",
+          "status": "public",
+          "version": "3.4",
+          "version_created": "2023-03-22T15:13:13.826802Z",
+          "relevant_disorders": [],
+          "stats": {
+            "number_of_genes": 39,
+            "number_of_strs": 2,
+            "number_of_regions": 5
+          },
+          "types": [
+            {
+              "name": "Rare Disease 100K",
+              "slug": "rare-disease-100k",
+              "description": "Rare Disease 100K"
+            },
+            {
+              "name": "Component Of Super Panel",
+              "slug": "component-of-super-panel",
+              "description": "This panel is a component of a Super Panel"
+            },
+            {
+              "name": "GMS signed-off",
+              "slug": "gms-signed-off",
+              "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+            },
+            {
+              "name": "GMS Rare Disease",
+              "slug": "gms-rare-disease",
+              "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+            }
+          ]
+        },
+        "transcript": null
+      }
+    ],
+    "regions": [
+      {
+        "gene_data": null,
+        "entity_type": "region",
+        "entity_name": "ISCA-37404-Loss",
+        "verbose_name": "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss",
+        "confidence_level": "3",
+        "penetrance": null,
+        "mode_of_pathogenicity": null,
+        "haploinsufficiency_score": "3",
+        "triplosensitivity_score": "",
+        "required_overlap_percentage": 60,
+        "type_of_variants": "cnv_loss",
+        "publications": [
+          "22045295",
+          "7611294"
+        ],
+        "evidence": [
+          "Expert Review Green",
+          "ClinGen"
+        ],
+        "phenotypes": [
+          "microcephaly",
+          "105833",
+          "Developmental delay, muscle weakness",
+          "Mental retardation",
+          "Angelman syndrome",
+          "176270",
+          "Prader-Willi syndrome"
+        ],
+        "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+        "chromosome": "15",
+        "grch37_coordinates": null,
+        "grch38_coordinates": [
+          22782170,
+          28134728
+        ],
+        "tags": [],
+        "panel": {
+          "id": 79,
+          "hash_id": "5541ef3dbb5a160c33b964e0",
+          "name": "Paediatric motor neuronopathies",
+          "disease_group": "Neurology and neurodevelopmental disorders",
+          "disease_sub_group": "Motor and Sensory Disorders of the PNS",
+          "status": "public",
+          "version": "3.4",
+          "version_created": "2023-03-22T15:13:13.826802Z",
+          "relevant_disorders": [],
+          "stats": {
+            "number_of_genes": 39,
+            "number_of_strs": 2,
+            "number_of_regions": 5
+          },
+          "types": [
+            {
+              "name": "Rare Disease 100K",
+              "slug": "rare-disease-100k",
+              "description": "Rare Disease 100K"
+            },
+            {
+              "name": "GMS Rare Disease",
+              "slug": "gms-rare-disease",
+              "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+            },
+            {
+              "name": "Component Of Super Panel",
+              "slug": "component-of-super-panel",
+              "description": "This panel is a component of a Super Panel"
+            },
+            {
+              "name": "GMS signed-off",
+              "slug": "gms-signed-off",
+              "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/testing_files/panelapp_api_mocks/superpanel_api_example_most_genes_removed.json
+++ b/testing_files/panelapp_api_mocks/superpanel_api_example_most_genes_removed.json
@@ -1,0 +1,225 @@
+{
+    "id": 465,
+    "hash_id": null,
+    "name": "Other rare neuromuscular disorders",
+    "disease_group": "",
+    "disease_sub_group": "",
+    "status": "public",
+    "version": "19.155",
+    "version_created": "2023-10-11T11:17:24.416918Z",
+    "relevant_disorders": [
+      "Neuromuscular disorders",
+      "R381"
+    ],
+    "stats": {
+      "number_of_genes": 453,
+      "number_of_strs": 7,
+      "number_of_regions": 8
+    },
+    "types": [
+      {
+        "name": "GMS Rare Disease Virtual",
+        "slug": "gms-rare-disease-virtual",
+        "description": "This is a panel for the Genomic Medicine Service for an exome/genome/panel based test that requires a virtual gene panel for rare disease in the Test Directory."
+      },
+      {
+        "name": "Super Panel",
+        "slug": "superpanel",
+        "description": "Superpanel"
+      },
+      {
+        "name": "GMS signed-off",
+        "slug": "gms-signed-off",
+        "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+      }
+    ],
+    "genes": [
+      {
+        "gene_data": {
+          "alias": [
+            "NPD002",
+            "MGC14452"
+          ],
+          "biotype": "protein_coding",
+          "hgnc_id": "HGNC:21497",
+          "gene_name": "acyl-CoA dehydrogenase family member 9",
+          "omim_gene": [
+            "611103"
+          ],
+          "alias_name": null,
+          "gene_symbol": "ACAD9",
+          "hgnc_symbol": "ACAD9",
+          "hgnc_release": "2017-11-03T00:00:00",
+          "ensembl_genes": {
+            "GRch37": {
+              "82": {
+                "location": "3:128598439-128634910",
+                "ensembl_id": "ENSG00000177646"
+              }
+            },
+            "GRch38": {
+              "90": {
+                "location": "3:128879596-128916067",
+                "ensembl_id": "ENSG00000177646"
+              }
+            }
+          },
+          "hgnc_date_symbol_changed": "2003-06-18"
+        },
+        "entity_type": "gene",
+        "entity_name": "ACAD9",
+        "confidence_level": "3",
+        "penetrance": "Complete",
+        "mode_of_pathogenicity": "",
+        "publications": [
+          "25929793"
+        ],
+        "evidence": [
+          "Expert Review Green",
+          "Radboud University Medical Center, Nijmegen",
+          "UKGTN",
+          "Illumina TruGenome Clinical Sequencing Services",
+          "Emory Genetics Laboratory",
+          "Literature"
+        ],
+        "phenotypes": [
+          "Mitochondrial complex I deficiency due to ACAD9 deficiency 611126"
+        ],
+        "mode_of_inheritance": "BIALLELIC, autosomal or pseudoautosomal",
+        "tags": [],
+        "panel": {
+          "id": 66,
+          "hash_id": "55b63d7f22c1fc05fc7a185b",
+          "name": "Rhabdomyolysis and metabolic muscle disorders",
+          "disease_group": "Neurology and neurodevelopmental disorders",
+          "disease_sub_group": "Neuromuscular disorders",
+          "status": "public",
+          "version": "3.37",
+          "version_created": "2023-10-11T11:17:19.655334Z",
+          "relevant_disorders": [],
+          "stats": {
+            "number_of_genes": 69,
+            "number_of_strs": 0,
+            "number_of_regions": 0
+          },
+          "types": [
+            {
+              "name": "Rare Disease 100K",
+              "slug": "rare-disease-100k",
+              "description": "Rare Disease 100K"
+            },
+            {
+              "name": "Component Of Super Panel",
+              "slug": "component-of-super-panel",
+              "description": "This panel is a component of a Super Panel"
+            },
+            {
+              "name": "GMS signed-off",
+              "slug": "gms-signed-off",
+              "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+            },
+            {
+              "name": "GMS Rare Disease",
+              "slug": "gms-rare-disease",
+              "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+            }
+          ]
+        },
+        "transcript": null
+      },
+      {
+        "gene_data": {
+          "alias": [
+            "MCAD",
+            "MCADH",
+            "ACAD1"
+          ],
+          "biotype": "protein_coding",
+          "hgnc_id": "HGNC:89",
+          "gene_name": "acyl-CoA dehydrogenase medium chain",
+          "omim_gene": [
+            "607008"
+          ],
+          "alias_name": [
+            "medium-chain acyl-CoA dehydrogenase"
+          ],
+          "gene_symbol": "ACADM",
+          "hgnc_symbol": "ACADM",
+          "hgnc_release": "2017-11-03T00:00:00",
+          "ensembl_genes": {
+            "GRch37": {
+              "82": {
+                "location": "1:76190036-76253260",
+                "ensembl_id": "ENSG00000117054"
+              }
+            },
+            "GRch38": {
+              "90": {
+                "location": "1:75724347-75787575",
+                "ensembl_id": "ENSG00000117054"
+              }
+            }
+          },
+          "hgnc_date_symbol_changed": "1986-01-01"
+        },
+        "entity_type": "gene",
+        "entity_name": "ACADM",
+        "confidence_level": "3",
+        "penetrance": "Complete",
+        "mode_of_pathogenicity": "",
+        "publications": [],
+        "evidence": [
+          "Expert Review Green",
+          "UKGTN",
+          "Radboud University Medical Center, Nijmegen",
+          "Illumina TruGenome Clinical Sequencing Services",
+          "Emory Genetics Laboratory"
+        ],
+        "phenotypes": [
+          "Rhabdomyolysis",
+          "Acyl-CoA dehydrogenase, medium chain, deficiency of\t201450"
+        ],
+        "mode_of_inheritance": "BIALLELIC, autosomal or pseudoautosomal",
+        "tags": [],
+        "panel": {
+          "id": 66,
+          "hash_id": "55b63d7f22c1fc05fc7a185b",
+          "name": "Rhabdomyolysis and metabolic muscle disorders",
+          "disease_group": "Neurology and neurodevelopmental disorders",
+          "disease_sub_group": "Neuromuscular disorders",
+          "status": "public",
+          "version": "3.37",
+          "version_created": "2023-10-11T11:17:19.655334Z",
+          "relevant_disorders": [],
+          "stats": {
+            "number_of_genes": 69,
+            "number_of_strs": 0,
+            "number_of_regions": 0
+          },
+          "types": [
+            {
+              "name": "Rare Disease 100K",
+              "slug": "rare-disease-100k",
+              "description": "Rare Disease 100K"
+            },
+            {
+              "name": "Component Of Super Panel",
+              "slug": "component-of-super-panel",
+              "description": "This panel is a component of a Super Panel"
+            },
+            {
+              "name": "GMS signed-off",
+              "slug": "gms-signed-off",
+              "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+            },
+            {
+              "name": "GMS Rare Disease",
+              "slug": "gms-rare-disease",
+              "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+            }
+          ]
+        },
+        "transcript": null
+      }
+    ]
+  }

--- a/testing_files/panelapp_api_mocks/superpanel_api_example_most_regions_removed.json
+++ b/testing_files/panelapp_api_mocks/superpanel_api_example_most_regions_removed.json
@@ -1,0 +1,185 @@
+{
+    "id": 465,
+    "hash_id": null,
+    "name": "Other rare neuromuscular disorders",
+    "disease_group": "",
+    "disease_sub_group": "",
+    "status": "public",
+    "version": "19.155",
+    "version_created": "2023-10-11T11:17:24.416918Z",
+    "relevant_disorders": [
+      "Neuromuscular disorders",
+      "R381"
+    ],
+    "stats": {
+      "number_of_genes": 453,
+      "number_of_strs": 7,
+      "number_of_regions": 8
+    },
+    "types": [
+      {
+        "name": "GMS Rare Disease Virtual",
+        "slug": "gms-rare-disease-virtual",
+        "description": "This is a panel for the Genomic Medicine Service for an exome/genome/panel based test that requires a virtual gene panel for rare disease in the Test Directory."
+      },
+      {
+        "name": "Super Panel",
+        "slug": "superpanel",
+        "description": "Superpanel"
+      },
+      {
+        "name": "GMS signed-off",
+        "slug": "gms-signed-off",
+        "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+      }
+    ],
+    "regions": [
+      {
+        "gene_data": null,
+        "entity_type": "region",
+        "entity_name": "ISCA-37404-Loss",
+        "verbose_name": "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss",
+        "confidence_level": "3",
+        "penetrance": null,
+        "mode_of_pathogenicity": null,
+        "haploinsufficiency_score": "3",
+        "triplosensitivity_score": "",
+        "required_overlap_percentage": 60,
+        "type_of_variants": "cnv_loss",
+        "publications": [
+          "22045295",
+          "7611294"
+        ],
+        "evidence": [
+          "Expert Review Green",
+          "ClinGen"
+        ],
+        "phenotypes": [
+          "microcephaly",
+          "105833",
+          "Developmental delay, muscle weakness",
+          "Mental retardation",
+          "Angelman syndrome",
+          "176270",
+          "Prader-Willi syndrome"
+        ],
+        "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+        "chromosome": "15",
+        "grch37_coordinates": null,
+        "grch38_coordinates": [
+          22782170,
+          28134728
+        ],
+        "tags": [],
+        "panel": {
+          "id": 79,
+          "hash_id": "5541ef3dbb5a160c33b964e0",
+          "name": "Paediatric motor neuronopathies",
+          "disease_group": "Neurology and neurodevelopmental disorders",
+          "disease_sub_group": "Motor and Sensory Disorders of the PNS",
+          "status": "public",
+          "version": "3.4",
+          "version_created": "2023-03-22T15:13:13.826802Z",
+          "relevant_disorders": [],
+          "stats": {
+            "number_of_genes": 39,
+            "number_of_strs": 2,
+            "number_of_regions": 5
+          },
+          "types": [
+            {
+              "name": "Rare Disease 100K",
+              "slug": "rare-disease-100k",
+              "description": "Rare Disease 100K"
+            },
+            {
+              "name": "GMS Rare Disease",
+              "slug": "gms-rare-disease",
+              "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+            },
+            {
+              "name": "Component Of Super Panel",
+              "slug": "component-of-super-panel",
+              "description": "This panel is a component of a Super Panel"
+            },
+            {
+              "name": "GMS signed-off",
+              "slug": "gms-signed-off",
+              "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+            }
+          ]
+        }
+      },
+      {
+        "gene_data": null,
+        "entity_type": "region",
+        "entity_name": "ISCA-37408-Loss",
+        "verbose_name": "2p15p16.1 region (includes BCL11A) Loss",
+        "confidence_level": "3",
+        "penetrance": null,
+        "mode_of_pathogenicity": null,
+        "haploinsufficiency_score": "3",
+        "triplosensitivity_score": "",
+        "required_overlap_percentage": 60,
+        "type_of_variants": "cnv_loss",
+        "publications": [
+          "16963482",
+          "22579565",
+          "18245392"
+        ],
+        "evidence": [
+          "Expert Review Green",
+          "ClinGen"
+        ],
+        "phenotypes": [
+          "Dysmorphic features, moderate to severe intellectual disability, microcephaly and renal anomalies"
+        ],
+        "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+        "chromosome": "2",
+        "grch37_coordinates": null,
+        "grch38_coordinates": [
+          58912065,
+          62261736
+        ],
+        "tags": [],
+        "panel": {
+          "id": 79,
+          "hash_id": "5541ef3dbb5a160c33b964e0",
+          "name": "Paediatric motor neuronopathies",
+          "disease_group": "Neurology and neurodevelopmental disorders",
+          "disease_sub_group": "Motor and Sensory Disorders of the PNS",
+          "status": "public",
+          "version": "3.4",
+          "version_created": "2023-03-22T15:13:13.826802Z",
+          "relevant_disorders": [],
+          "stats": {
+            "number_of_genes": 39,
+            "number_of_strs": 2,
+            "number_of_regions": 5
+          },
+          "types": [
+            {
+              "name": "Rare Disease 100K",
+              "slug": "rare-disease-100k",
+              "description": "Rare Disease 100K"
+            },
+            {
+              "name": "GMS Rare Disease",
+              "slug": "gms-rare-disease",
+              "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+            },
+            {
+              "name": "Component Of Super Panel",
+              "slug": "component-of-super-panel",
+              "description": "This panel is a component of a Super Panel"
+            },
+            {
+              "name": "GMS signed-off",
+              "slug": "gms-signed-off",
+              "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+            }
+          ]
+        }
+      }       
+    ]
+  }

--- a/testing_files/panelapp_api_mocks/superpanel_api_example_one_gene_two_panels.json
+++ b/testing_files/panelapp_api_mocks/superpanel_api_example_one_gene_two_panels.json
@@ -1,0 +1,223 @@
+{
+    "id": 465,
+    "hash_id": null,
+    "name": "Other rare neuromuscular disorders",
+    "disease_group": "",
+    "disease_sub_group": "",
+    "status": "public",
+    "version": "19.156",
+    "version_created": "2023-10-16T16:58:09.745398Z",
+    "relevant_disorders": [
+      "Neuromuscular disorders",
+      "R381"
+    ],
+    "stats": {
+      "number_of_genes": 453,
+      "number_of_strs": 7,
+      "number_of_regions": 8
+    },
+    "genes": [
+    {
+    "gene_data": {
+      "alias": [
+        "ABP-280",
+        "ABPL"
+      ],
+      "biotype": "protein_coding",
+      "hgnc_id": "HGNC:3756",
+      "gene_name": "filamin C",
+      "omim_gene": [
+        "102565"
+      ],
+      "alias_name": [
+        "actin binding protein 280",
+        "gamma filamin"
+      ],
+      "gene_symbol": "FLNC",
+      "hgnc_symbol": "FLNC",
+      "hgnc_release": "2017-11-03T00:00:00",
+      "ensembl_genes": {
+        "GRch37": {
+          "82": {
+            "location": "7:128470431-128499328",
+            "ensembl_id": "ENSG00000128591"
+          }
+        },
+        "GRch38": {
+          "90": {
+            "location": "7:128830377-128859274",
+            "ensembl_id": "ENSG00000128591"
+          }
+        }
+      },
+      "hgnc_date_symbol_changed": "1993-08-24"
+    },
+    "entity_type": "gene",
+    "entity_name": "FLNC",
+    "confidence_level": "2",
+    "penetrance": "Complete",
+    "mode_of_pathogenicity": "",
+    "publications": [
+      "29858533"
+    ],
+    "evidence": [
+      "NHS GMS",
+      "Expert Review",
+      "Expert Review Amber",
+      "Radboud University Medical Center, Nijmegen"
+    ],
+    "phenotypes": [
+      "Myopathy, distal, 4, OMIM:614065",
+      "Myopathy, myofibrillar, 5, OMIM:609524"
+    ],
+    "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+    "tags": [],
+    "panel": {
+      "id": 225,
+      "hash_id": "553f94b6bb5a1616e5ed459a",
+      "name": "Congenital myopathy",
+      "disease_group": "Neurology and neurodevelopmental disorders",
+      "disease_sub_group": "Neuromuscular disorders",
+      "status": "public",
+      "version": "4.31",
+      "version_created": "2023-10-16T16:58:04.766187Z",
+      "relevant_disorders": [
+        "R81"
+      ],
+      "stats": {
+        "number_of_genes": 123,
+        "number_of_strs": 2,
+        "number_of_regions": 3
+      },
+      "types": [
+        {
+          "name": "Rare Disease 100K",
+          "slug": "rare-disease-100k",
+          "description": "Rare Disease 100K"
+        },
+        {
+          "name": "GMS Rare Disease",
+          "slug": "gms-rare-disease",
+          "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+        },
+        {
+          "name": "Component Of Super Panel",
+          "slug": "component-of-super-panel",
+          "description": "This panel is a component of a Super Panel"
+        },
+        {
+          "name": "GMS signed-off",
+          "slug": "gms-signed-off",
+          "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+        }
+      ]
+    },
+    "transcript": null
+    },
+    {
+    "gene_data": {
+      "alias": [
+        "ABP-280",
+        "ABPL"
+      ],
+      "biotype": "protein_coding",
+      "hgnc_id": "HGNC:3756",
+      "gene_name": "filamin C",
+      "omim_gene": [
+        "102565"
+      ],
+      "alias_name": [
+        "actin binding protein 280",
+        "gamma filamin"
+      ],
+      "gene_symbol": "FLNC",
+      "hgnc_symbol": "FLNC",
+      "hgnc_release": "2017-11-03T00:00:00",
+      "ensembl_genes": {
+        "GRch37": {
+          "82": {
+            "location": "7:128470431-128499328",
+            "ensembl_id": "ENSG00000128591"
+          }
+        },
+        "GRch38": {
+          "90": {
+            "location": "7:128830377-128859274",
+            "ensembl_id": "ENSG00000128591"
+          }
+        }
+      },
+      "hgnc_date_symbol_changed": "1993-08-24"
+    },
+    "entity_type": "gene",
+    "entity_name": "FLNC",
+    "confidence_level": "3",
+    "penetrance": "Complete",
+    "mode_of_pathogenicity": "",
+    "publications": [
+      "15929027",
+      "17412757",
+      "19050726",
+      "22806379"
+    ],
+    "evidence": [
+      "Expert Review Green",
+      "Literature",
+      "Emory Genetics Laboratory"
+    ],
+    "phenotypes": [
+      "Myopathy, distal, 4, OMIM:614065",
+      "Distal myopathy with posterior leg and anterior hand involvement, MONDO:0013550",
+      "Myopathy, myofibrillar, 5, OMIM:609524",
+      "Myopathy, myofibrillar, 5, MONDO:0012289"
+    ],
+    "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, NOT imprinted",
+    "tags": [],
+    "panel": {
+      "id": 185,
+      "hash_id": "55b7a65322c1fc05fc7a1869",
+      "name": "Limb girdle muscular dystrophies, myofibrillar myopathies and distal myopathies",
+      "disease_group": "Neurology and neurodevelopmental disorders",
+      "disease_sub_group": "Neuromuscular disorders",
+      "status": "public",
+      "version": "4.22",
+      "version_created": "2023-08-22T16:30:38.039837Z",
+      "relevant_disorders": [
+        "Limb girdle muscular dystrophy",
+        "R82"
+      ],
+      "stats": {
+        "number_of_genes": 96,
+        "number_of_strs": 0,
+        "number_of_regions": 0
+      },
+      "types": [
+        {
+          "name": "Rare Disease 100K",
+          "slug": "rare-disease-100k",
+          "description": "Rare Disease 100K"
+        },
+        {
+          "name": "Component Of Super Panel",
+          "slug": "component-of-super-panel",
+          "description": "This panel is a component of a Super Panel"
+        },
+        {
+          "name": "GMS signed-off",
+          "slug": "gms-signed-off",
+          "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+        },
+        {
+          "name": "GMS Rare Disease",
+          "slug": "gms-rare-disease",
+          "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+        }
+      ]
+    },
+    "transcript": null
+    }
+    ],
+    "regions": [
+    ]
+  }
+  

--- a/testing_files/panelapp_api_mocks/superpanel_api_example_one_region_two_panels.json
+++ b/testing_files/panelapp_api_mocks/superpanel_api_example_one_region_two_panels.json
@@ -1,0 +1,190 @@
+{
+    "id": 465,
+    "hash_id": null,
+    "name": "Other rare neuromuscular disorders",
+    "disease_group": "",
+    "disease_sub_group": "",
+    "status": "public",
+    "version": "19.156",
+    "version_created": "2023-10-16T16:58:09.745398Z",
+    "relevant_disorders": [
+      "Neuromuscular disorders",
+      "R381"
+    ],
+    "stats": {
+      "number_of_genes": 453,
+      "number_of_strs": 7,
+      "number_of_regions": 8
+    },
+    "types": [
+      {
+        "name": "GMS Rare Disease Virtual",
+        "slug": "gms-rare-disease-virtual",
+        "description": "This is a panel for the Genomic Medicine Service for an exome/genome/panel based test that requires a virtual gene panel for rare disease in the Test Directory."
+      },
+      {
+        "name": "Super Panel",
+        "slug": "superpanel",
+        "description": "Superpanel"
+      },
+      {
+        "name": "GMS signed-off",
+        "slug": "gms-signed-off",
+        "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+      }
+    ],
+    "regions": [
+      {
+        "gene_data": null,
+        "entity_type": "region",
+        "entity_name": "ISCA-37404-Loss",
+        "verbose_name": "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss",
+        "confidence_level": "3",
+        "penetrance": null,
+        "mode_of_pathogenicity": null,
+        "haploinsufficiency_score": "3",
+        "triplosensitivity_score": "",
+        "required_overlap_percentage": 60,
+        "type_of_variants": "cnv_loss",
+        "publications": [
+          "22045295",
+          "7611294"
+        ],
+        "evidence": [
+          "Expert Review Green",
+          "ClinGen"
+        ],
+        "phenotypes": [
+          "microcephaly",
+          "105833",
+          "Developmental delay, muscle weakness",
+          "Mental retardation",
+          "Angelman syndrome",
+          "176270",
+          "Prader-Willi syndrome"
+        ],
+        "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+        "chromosome": "15",
+        "grch37_coordinates": null,
+        "grch38_coordinates": [
+          22782170,
+          28134728
+        ],
+        "tags": [],
+        "panel": {
+          "id": 79,
+          "hash_id": "5541ef3dbb5a160c33b964e0",
+          "name": "Paediatric motor neuronopathies",
+          "disease_group": "Neurology and neurodevelopmental disorders",
+          "disease_sub_group": "Motor and Sensory Disorders of the PNS",
+          "status": "public",
+          "version": "3.4",
+          "version_created": "2023-03-22T15:13:13.826802Z",
+          "relevant_disorders": [],
+          "stats": {
+            "number_of_genes": 39,
+            "number_of_strs": 2,
+            "number_of_regions": 5
+          },
+          "types": [
+            {
+              "name": "Rare Disease 100K",
+              "slug": "rare-disease-100k",
+              "description": "Rare Disease 100K"
+            },
+            {
+              "name": "GMS Rare Disease",
+              "slug": "gms-rare-disease",
+              "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+            },
+            {
+              "name": "Component Of Super Panel",
+              "slug": "component-of-super-panel",
+              "description": "This panel is a component of a Super Panel"
+            },
+            {
+              "name": "GMS signed-off",
+              "slug": "gms-signed-off",
+              "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+            }
+          ]
+        }
+      },
+      {
+        "gene_data": null,
+        "entity_type": "region",
+        "entity_name": "ISCA-37404-Loss",
+        "verbose_name": "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss",
+        "confidence_level": "3",
+        "penetrance": null,
+        "mode_of_pathogenicity": null,
+        "haploinsufficiency_score": "3",
+        "triplosensitivity_score": "",
+        "required_overlap_percentage": 60,
+        "type_of_variants": "cnv_loss",
+        "publications": [
+        "22045295",
+        "7611294"
+        ],
+        "evidence": [
+        "Expert Review Green",
+        "ClinGen"
+        ],
+        "phenotypes": [
+        "microcephaly",
+        "105833",
+        "Developmental delay, muscle weakness",
+        "Mental retardation",
+        "Angelman syndrome",
+        "176270",
+        "Prader-Willi syndrome"
+        ],
+        "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+        "chromosome": "15",
+        "grch37_coordinates": null,
+        "grch38_coordinates": [
+        22782170,
+        28134728
+        ],
+        "tags": [],
+        "panel": {
+            "id": 100,
+            "hash_id": "test",
+            "name": "Other motor neuronopathies",
+            "disease_group": "Neurology and neurodevelopmental disorders",
+            "disease_sub_group": "Motor and Sensory Disorders of the PNS",
+            "status": "public",
+            "version": "3.6",
+            "version_created": "2023-03-22T15:13:13.826802Z",
+            "relevant_disorders": [],
+            "stats": {
+                "number_of_genes": 39,
+                "number_of_strs": 2,
+                "number_of_regions": 5
+            },
+            "types": [
+                {
+                "name": "Rare Disease 100K",
+                "slug": "rare-disease-100k",
+                "description": "Rare Disease 100K"
+                },
+                {
+                "name": "GMS Rare Disease",
+                "slug": "gms-rare-disease",
+                "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
+                },
+                {
+                "name": "Component Of Super Panel",
+                "slug": "component-of-super-panel",
+                "description": "This panel is a component of a Super Panel"
+                },
+                {
+                "name": "GMS signed-off",
+                "slug": "gms-signed-off",
+                "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
+                }
+            ]
+        }
+    }
+    ]
+  }

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
@@ -161,8 +161,8 @@ class TestFlagClinicalIndicationSuperpanelForReview(TestCase):
             panel_version=sortable_version("1.15"),
         )
 
-        self.first_clinical_indication_superpanel = ClinicalIndicationSuperPanel.\
-            objects.create(
+        self.first_clinical_indication_superpanel = \
+            ClinicalIndicationSuperPanel.objects.create(
                 config_source=None,
                 td_version=None,
                 clinical_indication=self.first_clinical_indication,
@@ -172,7 +172,7 @@ class TestFlagClinicalIndicationSuperpanelForReview(TestCase):
 
     def test_that_link_will_be_flagged_and_history_recorded(self):
         """
-        test that given a clinical indication-superpanel link, the link will be 
+        test that given a clinical indication-superpanel link, the link will be
         flagged for review and current set to False
         and history recorded in ClinicalIndicationSuperPanelHistory
         """
@@ -183,8 +183,8 @@ class TestFlagClinicalIndicationSuperpanelForReview(TestCase):
 
         self.first_clinical_indication_superpanel.refresh_from_db()
 
-        assert self.first_clinical_indication_superpanel.pending == True
-        assert self.first_clinical_indication_superpanel.current == False
+        assert self.first_clinical_indication_superpanel.pending
+        assert not self.first_clinical_indication_superpanel.current
 
         assert (
             ClinicalIndicationSuperPanelHistory.objects.count() == 1
@@ -274,8 +274,8 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
             panel_version=sortable_version("1.15"),
         )
 
-        self.first_clinical_indication_superpanel = ClinicalIndicationSuperPanel.\
-            objects.create(
+        self.first_clinical_indication_superpanel = \
+            ClinicalIndicationSuperPanel.objects.create(
                 config_source=None,
                 td_version=None,
                 clinical_indication=self.first_clinical_indication,
@@ -287,17 +287,19 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
     def test_that_existing_superpanel_link_is_flagged(self):
         """
         `provisionally_link_clinical_indication_to_superpanel` links a panel
-        to a clinical indication to create a clinical indication-superpanel link
+        to a clinical indication to create a clinical indication-superpanel
+        link
 
-        - the general output is that the link will be created but also flagged for review 
-        (expect `pending` to be True)
-        - we expect this behaviour for both new or existing clinical indication-superpanel link
+        - the general output is that the link will be created but also flagged for
+        review (expect `pending` to be True)
+        - we expect this behaviour for both new or existing clinical
+        indication-superpanel link
 
         below we test for an existing link
         example:
-            superpanel 123 is already linked to clinical indication R123 as we setup above 
-            (with `pending` set to False)
-            we expect the `pending` to turn True after calling 
+            superpanel 123 is already linked to clinical indication R123 as we setup
+            above (with `pending` set to False)
+            we expect the `pending` to turn True after calling
             `provisionally_link_clinical_indication_to_superpanel` on it
         """
 
@@ -309,14 +311,15 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
 
         self.first_clinical_indication_superpanel.refresh_from_db()
 
-        assert self.first_clinical_indication_superpanel.pending == True
+        assert self.first_clinical_indication_superpanel.pending
 
     def test_that_new_link_is_flagged(self):
         """
-        we test for a new link (not existing in db) - self.second_clinical_indication 
-        is not linked to self.first_superpanel in setup
-        `provisionally_link_clinical_indication_to_panel` should create the link and 
-        flag it for review
+        we test for a new link (not existing in db) - 
+        self.second_clinical_indication is not linked to self.first_superpanel
+        in setup
+        `provisionally_link_clinical_indication_to_panel` should create the
+        link and flag it for review
         """
         provisionally_link_clinical_indication_to_superpanel(
             self.first_superpanel,
@@ -324,11 +327,13 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
             "test",
         )
 
-        assert ClinicalIndicationSuperPanel.objects.count() == 2  # one new link created
+        # one new link created
+        assert ClinicalIndicationSuperPanel.objects.count() == 2
 
         new_link = ClinicalIndicationSuperPanel.objects.last()
-
-        assert new_link.pending == True  # new link should be flagged for review
+        
+        # new link should be flagged for review
+        assert new_link.pending
 
 class TestGetTDVersion(TestCase):
     """

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
@@ -125,7 +125,7 @@ class TestFlagClinicalIndicationPanelForReview(TestCase):
         """
 
         flag_clinical_indication_panel_for_review(
-            self.first_clinical_indication_panel, "test"
+            self.first_clinical_indication_panel, False, "test"
         )
 
         self.first_clinical_indication_panel.refresh_from_db()

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
@@ -107,6 +107,7 @@ class TestFlagClinicalIndicationPanelForReview(TestCase):
     """
     Tests that flagging Clinical Indication - Panel links works correctly
     """
+
     def setUp(self) -> None:
         self.first_clinical_indication = ClinicalIndication.objects.create(
             r_code="R123", name="Test CI", test_method="Test method"
@@ -150,6 +151,7 @@ class TestFlagClinicalIndicationSuperpanelForReview(TestCase):
     """
     Tests that flagging Clinical Indication - SuperPanel links works correctly
     """
+
     def setUp(self) -> None:
         self.first_clinical_indication = ClinicalIndication.objects.create(
             r_code="R123", name="Test CI", test_method="Test method"
@@ -161,7 +163,7 @@ class TestFlagClinicalIndicationSuperpanelForReview(TestCase):
             panel_version=sortable_version("1.15"),
         )
 
-        self.first_clinical_indication_superpanel = \
+        self.first_clinical_indication_superpanel = (
             ClinicalIndicationSuperPanel.objects.create(
                 config_source=None,
                 td_version=None,
@@ -169,6 +171,7 @@ class TestFlagClinicalIndicationSuperpanelForReview(TestCase):
                 superpanel=self.first_superpanel,
                 current=True,
             )
+        )
 
     def test_that_link_will_be_flagged_and_history_recorded(self):
         """
@@ -274,7 +277,7 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
             panel_version=sortable_version("1.15"),
         )
 
-        self.first_clinical_indication_superpanel = \
+        self.first_clinical_indication_superpanel = (
             ClinicalIndicationSuperPanel.objects.create(
                 config_source=None,
                 td_version=None,
@@ -283,6 +286,7 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
                 current=True,
                 pending=False,
             )
+        )
 
     def test_that_existing_superpanel_link_is_flagged(self):
         """
@@ -304,9 +308,7 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
         """
 
         provisionally_link_clinical_indication_to_superpanel(
-            self.first_superpanel,
-            self.first_clinical_indication,
-            "test"
+            self.first_superpanel, self.first_clinical_indication, "test"
         )  # this is an existing link in db
 
         self.first_clinical_indication_superpanel.refresh_from_db()
@@ -315,7 +317,7 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
 
     def test_that_new_link_is_flagged(self):
         """
-        we test for a new link (not existing in db) - 
+        we test for a new link (not existing in db) -
         self.second_clinical_indication is not linked to self.first_superpanel
         in setup
         `provisionally_link_clinical_indication_to_panel` should create the
@@ -331,9 +333,10 @@ class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
         assert ClinicalIndicationSuperPanel.objects.count() == 2
 
         new_link = ClinicalIndicationSuperPanel.objects.last()
-        
+
         # new link should be flagged for review
         assert new_link.pending
+
 
 class TestGetTDVersion(TestCase):
     """

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
@@ -13,15 +13,20 @@ from django.test import TestCase
 from requests_app.models import (
     ClinicalIndication,
     Panel,
+    SuperPanel,
     ClinicalIndicationPanel,
+    ClinicalIndicationSuperPanel,
     ClinicalIndicationPanelHistory,
+    ClinicalIndicationSuperPanelHistory,
     ClinicalIndicationTestMethodHistory,
 )
 from requests_app.management.commands.utils import sortable_version
 from requests_app.management.commands._insert_ci import (
     _backward_deactivate,
     flag_clinical_indication_panel_for_review,
+    flag_clinical_indication_superpanel_for_review,
     provisionally_link_clinical_indication_to_panel,
+    provisionally_link_clinical_indication_to_superpanel,
     _get_td_version,
     _retrieve_panel_from_pa_id,
     _retrieve_unknown_metadata_records,
@@ -99,6 +104,9 @@ class TestBackwardDeactivation(TestCase):
 
 
 class TestFlagClinicalIndicationPanelForReview(TestCase):
+    """
+    Tests that flagging Clinical Indication - Panel links works correctly
+    """
     def setUp(self) -> None:
         self.first_clinical_indication = ClinicalIndication.objects.create(
             r_code="R123", name="Test CI", test_method="Test method"
@@ -125,7 +133,7 @@ class TestFlagClinicalIndicationPanelForReview(TestCase):
         """
 
         flag_clinical_indication_panel_for_review(
-            self.first_clinical_indication_panel, False, "test"
+            self.first_clinical_indication_panel, "test"
         )
 
         self.first_clinical_indication_panel.refresh_from_db()
@@ -135,6 +143,51 @@ class TestFlagClinicalIndicationPanelForReview(TestCase):
 
         assert (
             ClinicalIndicationPanelHistory.objects.count() == 1
+        )  # one history recorded
+
+
+class TestFlagClinicalIndicationSuperpanelForReview(TestCase):
+    """
+    Tests that flagging Clinical Indication - SuperPanel links works correctly
+    """
+    def setUp(self) -> None:
+        self.first_clinical_indication = ClinicalIndication.objects.create(
+            r_code="R123", name="Test CI", test_method="Test method"
+        )
+
+        self.first_superpanel = SuperPanel.objects.create(
+            external_id=123,
+            panel_name="Test panel",
+            panel_version=sortable_version("1.15"),
+        )
+
+        self.first_clinical_indication_superpanel = ClinicalIndicationSuperPanel.\
+            objects.create(
+                config_source=None,
+                td_version=None,
+                clinical_indication=self.first_clinical_indication,
+                superpanel=self.first_superpanel,
+                current=True,
+            )
+
+    def test_that_link_will_be_flagged_and_history_recorded(self):
+        """
+        test that given a clinical indication-superpanel link, the link will be 
+        flagged for review and current set to False
+        and history recorded in ClinicalIndicationSuperPanelHistory
+        """
+
+        flag_clinical_indication_superpanel_for_review(
+            self.first_clinical_indication_superpanel, "test"
+        )
+
+        self.first_clinical_indication_superpanel.refresh_from_db()
+
+        assert self.first_clinical_indication_superpanel.pending == True
+        assert self.first_clinical_indication_superpanel.current == False
+
+        assert (
+            ClinicalIndicationSuperPanelHistory.objects.count() == 1
         )  # one history recorded
 
 
@@ -204,6 +257,78 @@ class TestProvisionallyLinkClinicalIndicationToPanel(TestCase):
 
         assert new_link.pending == True  # new link should be flagged for review
 
+
+class TestProvisionallyLinkClinicalIndicationToSuperPanel(TestCase):
+    def setUp(self) -> None:
+        self.first_clinical_indication = ClinicalIndication.objects.create(
+            r_code="R123", name="Test CI", test_method="Test method"
+        )
+
+        self.second_clinical_indication = ClinicalIndication.objects.create(
+            r_code="R123", name="Test CI 2", test_method="Test method"
+        )
+
+        self.first_superpanel = SuperPanel.objects.create(
+            external_id=123,
+            panel_name="Test panel",
+            panel_version=sortable_version("1.15"),
+        )
+
+        self.first_clinical_indication_superpanel = ClinicalIndicationSuperPanel.\
+            objects.create(
+                config_source=None,
+                td_version=None,
+                clinical_indication=self.first_clinical_indication,
+                superpanel=self.first_superpanel,
+                current=True,
+                pending=False,
+            )
+
+    def test_that_existing_superpanel_link_is_flagged(self):
+        """
+        `provisionally_link_clinical_indication_to_superpanel` links a panel
+        to a clinical indication to create a clinical indication-superpanel link
+
+        - the general output is that the link will be created but also flagged for review 
+        (expect `pending` to be True)
+        - we expect this behaviour for both new or existing clinical indication-superpanel link
+
+        below we test for an existing link
+        example:
+            superpanel 123 is already linked to clinical indication R123 as we setup above 
+            (with `pending` set to False)
+            we expect the `pending` to turn True after calling 
+            `provisionally_link_clinical_indication_to_superpanel` on it
+        """
+
+        provisionally_link_clinical_indication_to_superpanel(
+            self.first_superpanel,
+            self.first_clinical_indication,
+            "test"
+        )  # this is an existing link in db
+
+        self.first_clinical_indication_superpanel.refresh_from_db()
+
+        assert self.first_clinical_indication_superpanel.pending == True
+
+    def test_that_new_link_is_flagged(self):
+        """
+        we test for a new link (not existing in db) - self.second_clinical_indication 
+        is not linked to self.first_superpanel in setup
+        `provisionally_link_clinical_indication_to_panel` should create the link and 
+        flag it for review
+        """
+        provisionally_link_clinical_indication_to_superpanel(
+            self.first_superpanel,
+            self.second_clinical_indication,
+            "test",
+        )
+
+        assert ClinicalIndicationSuperPanel.objects.count() == 2  # one new link created
+
+        new_link = ClinicalIndicationSuperPanel.objects.last()
+
+        assert new_link.pending == True  # new link should be flagged for review
 
 class TestGetTDVersion(TestCase):
     """

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
@@ -1,0 +1,162 @@
+from django.test import TestCase
+
+from requests_app.models import (
+    PanelGene,
+    Panel,
+    SuperPanel,
+    ClinicalIndication,
+    ClinicalIndicationPanel,
+    ClinicalIndicationSuperPanel
+)
+from requests_app.management.commands._insert_ci import _fetch_latest_td_version
+from requests_app.management.commands.utils import sortable_version
+from tests.tests_requests_app.test_management.test_commands.test_insert_panel.test_insert_gene import (
+    len_check_wrapper,
+    value_check_wrapper,
+)
+
+
+class TestFetchLatestTdVersion_OlderPanel(TestCase):
+    def setUp(self) -> None:
+        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
+                           name="An illness",
+                           test_method="NGS"
+                           )
+
+        self.panel = Panel.objects.create(
+            external_id=500,
+            panel_source="PanelApp",
+            panel_version=6
+        )
+
+        self.superpanel= SuperPanel.objects.create(
+            external_id=500,
+            panel_source="PanelApp",
+            panel_version=6
+        )
+
+        self.ci_panel = ClinicalIndicationPanel.objects.create(
+            config_source="test",
+            td_version="3",
+            clinical_indication=self.ci,
+            panel=self.panel,
+            current=True
+        )
+
+        self.ci_superpanel = ClinicalIndicationSuperPanel.objects.create(
+            config_source="test",
+            td_version="2",
+            clinical_indication=self.ci,
+            superpanel=self.superpanel,
+            current=True
+        )
+    
+    def test_panel_older_than_superpanel(self):
+        latest_td = _fetch_latest_td_version()
+
+        assert latest_td == sortable_version("3")
+
+
+class TestFetchLatestTdVersion_OlderSuperPanel(TestCase):
+    def setUp(self) -> None:
+        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
+                           name="An illness",
+                           test_method="NGS"
+                           )
+
+        self.panel = Panel.objects.create(
+            external_id=500,
+            panel_source="PanelApp",
+            panel_version=6
+        )
+
+        self.superpanel= SuperPanel.objects.create(
+            external_id=500,
+            panel_source="PanelApp",
+            panel_version=6
+        )
+
+        self.ci_panel = ClinicalIndicationPanel.objects.create(
+            config_source="test",
+            td_version="3",
+            clinical_indication=self.ci,
+            panel=self.panel,
+            current=True
+        )
+
+        self.ci_superpanel = ClinicalIndicationSuperPanel.objects.create(
+            config_source="test",
+            td_version="4",
+            clinical_indication=self.ci,
+            superpanel=self.superpanel,
+            current=True
+        )
+    
+    def test_superpanel_older_than_panel(self):
+        latest_td = _fetch_latest_td_version()
+
+        assert latest_td == sortable_version("4")
+
+
+class TestFetchLatestTdVersion_PanelOnly(TestCase):
+    def setUp(self) -> None:
+        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
+                           name="An illness",
+                           test_method="NGS"
+                           )
+
+        self.panel = Panel.objects.create(
+            external_id=500,
+            panel_source="PanelApp",
+            panel_version=6
+        )
+
+        self.ci_panel = ClinicalIndicationPanel.objects.create(
+            config_source="test",
+            td_version="3",
+            clinical_indication=self.ci,
+            panel=self.panel,
+            current=True
+        )
+    
+    def test_only_panel_exists(self):
+        latest_td = _fetch_latest_td_version()
+
+        assert latest_td == sortable_version("3")
+
+
+class TestFetchLatestTdVersion_SuperPanelOnly(TestCase):
+    def setUp(self) -> None:
+        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
+                           name="An illness",
+                           test_method="NGS"
+                           )
+
+        self.panel = SuperPanel.objects.create(
+            external_id=500,
+            panel_source="PanelApp",
+            panel_version=6
+        )
+
+        self.ci_panel = ClinicalIndicationSuperPanel.objects.create(
+            config_source="test",
+            td_version="3",
+            clinical_indication=self.ci,
+            superpanel=self.panel,
+            current=True
+        )
+    
+    def test_only_panel_exists(self):
+        latest_td = _fetch_latest_td_version()
+
+        assert latest_td == sortable_version("3")
+
+
+class TestFetchLatestTdVersion_NoDataAvailable(TestCase):
+    def setUp(self) -> None:
+        pass
+    
+    def test_only_panel_exists(self):
+        latest_td = _fetch_latest_td_version()
+
+        assert latest_td == None

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
@@ -17,6 +17,11 @@ from tests.tests_requests_app.test_management.test_commands.test_insert_panel.te
 
 
 class TestFetchLatestTdVersion_OlderPanel(TestCase):
+    """
+    Check that when the latest td version is in the Panel,
+    the data is correctly returned
+    EXPECT: ClinicalIndicationPanel's td version is returned as correct
+    """
     def setUp(self) -> None:
         self.ci = ClinicalIndication.objects.create(r_code="R100.1",
                            name="An illness",
@@ -52,12 +57,22 @@ class TestFetchLatestTdVersion_OlderPanel(TestCase):
         )
     
     def test_panel_older_than_superpanel(self):
+        """
+        Check that when the latest td version is in the Panel,
+        the data is correctly returned
+        EXPECT: ClinicalIndicationPanel's td version is returned as correct
+        """
         latest_td = _fetch_latest_td_version()
 
         assert latest_td == sortable_version("3")
 
 
 class TestFetchLatestTdVersion_OlderSuperPanel(TestCase):
+    """
+    Check that when the latest td version is in the SuperPanel,
+    the data is correctly returned
+    EXPECT: ClinicalIndicationSuperPanel's td version is returned as correct
+    """
     def setUp(self) -> None:
         self.ci = ClinicalIndication.objects.create(r_code="R100.1",
                            name="An illness",
@@ -93,12 +108,22 @@ class TestFetchLatestTdVersion_OlderSuperPanel(TestCase):
         )
     
     def test_superpanel_older_than_panel(self):
+        """
+        Check that when the latest td version is in the SuperPanel,
+        the data is correctly returned
+        EXPECT: ClinicalIndicationSuperPanel's td version is returned as correct
+        """
         latest_td = _fetch_latest_td_version()
 
         assert latest_td == sortable_version("4")
 
 
 class TestFetchLatestTdVersion_PanelOnly(TestCase):
+    """
+    Check that when there is no SuperPanel data in the db,
+    the td version in the panel-related data is correctly returned
+    EXPECT: ClinicalIndicationPanel's td version is returned as correct
+    """
     def setUp(self) -> None:
         self.ci = ClinicalIndication.objects.create(r_code="R100.1",
                            name="An illness",
@@ -120,12 +145,22 @@ class TestFetchLatestTdVersion_PanelOnly(TestCase):
         )
     
     def test_only_panel_exists(self):
+        """
+        Check that when there is no SuperPanel data in the db,
+        the td version in the panel-related data is correctly returned
+        EXPECT: ClinicalIndicationPanel's td version is returned as correct
+        """
         latest_td = _fetch_latest_td_version()
 
         assert latest_td == sortable_version("3")
 
 
 class TestFetchLatestTdVersion_SuperPanelOnly(TestCase):
+    """
+    Check that when there is no Panel data in the db,
+    the td version in the panel-related data is correctly returned
+    EXPECT: ClinicalIndicationSuperPanel's td version is returned as correct
+    """
     def setUp(self) -> None:
         self.ci = ClinicalIndication.objects.create(r_code="R100.1",
                            name="An illness",
@@ -147,12 +182,22 @@ class TestFetchLatestTdVersion_SuperPanelOnly(TestCase):
         )
     
     def test_only_panel_exists(self):
+        """
+        Check that when there is no Panel data in the db,
+        the td version in the panel-related data is correctly returned
+        EXPECT: ClinicalIndicationSuperPanel's td version is returned as correct
+        """
         latest_td = _fetch_latest_td_version()
 
         assert latest_td == sortable_version("3")
 
 
 class TestFetchLatestTdVersion_NoDataAvailable(TestCase):
+    """
+    Check that when there is no data in the db for panels or superpanels,
+    a None value is returned
+    EXPECT: td version returns as None
+    """
     def setUp(self) -> None:
         pass
     

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
@@ -205,3 +205,6 @@ class TestFetchLatestTdVersion_NoDataAvailable(TestCase):
         latest_td = _fetch_latest_td_version()
 
         assert latest_td == None
+
+
+#TODO: test '_check_td_version_valid' if concerned

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_td_version_functions.py
@@ -6,7 +6,7 @@ from requests_app.models import (
     SuperPanel,
     ClinicalIndication,
     ClinicalIndicationPanel,
-    ClinicalIndicationSuperPanel
+    ClinicalIndicationSuperPanel,
 )
 from requests_app.management.commands._insert_ci import _fetch_latest_td_version
 from requests_app.management.commands.utils import sortable_version
@@ -22,22 +22,18 @@ class TestFetchLatestTdVersion_OlderPanel(TestCase):
     the data is correctly returned
     EXPECT: ClinicalIndicationPanel's td version is returned as correct
     """
-    def setUp(self) -> None:
-        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
-                           name="An illness",
-                           test_method="NGS"
-                           )
 
-        self.panel = Panel.objects.create(
-            external_id=500,
-            panel_source="PanelApp",
-            panel_version=6
+    def setUp(self) -> None:
+        self.ci = ClinicalIndication.objects.create(
+            r_code="R100.1", name="An illness", test_method="NGS"
         )
 
-        self.superpanel= SuperPanel.objects.create(
-            external_id=500,
-            panel_source="PanelApp",
-            panel_version=6
+        self.panel = Panel.objects.create(
+            external_id=500, panel_source="PanelApp", panel_version=6
+        )
+
+        self.superpanel = SuperPanel.objects.create(
+            external_id=500, panel_source="PanelApp", panel_version=6
         )
 
         self.ci_panel = ClinicalIndicationPanel.objects.create(
@@ -45,7 +41,7 @@ class TestFetchLatestTdVersion_OlderPanel(TestCase):
             td_version="3",
             clinical_indication=self.ci,
             panel=self.panel,
-            current=True
+            current=True,
         )
 
         self.ci_superpanel = ClinicalIndicationSuperPanel.objects.create(
@@ -53,9 +49,9 @@ class TestFetchLatestTdVersion_OlderPanel(TestCase):
             td_version="2",
             clinical_indication=self.ci,
             superpanel=self.superpanel,
-            current=True
+            current=True,
         )
-    
+
     def test_panel_older_than_superpanel(self):
         """
         Check that when the latest td version is in the Panel,
@@ -73,22 +69,18 @@ class TestFetchLatestTdVersion_OlderSuperPanel(TestCase):
     the data is correctly returned
     EXPECT: ClinicalIndicationSuperPanel's td version is returned as correct
     """
-    def setUp(self) -> None:
-        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
-                           name="An illness",
-                           test_method="NGS"
-                           )
 
-        self.panel = Panel.objects.create(
-            external_id=500,
-            panel_source="PanelApp",
-            panel_version=6
+    def setUp(self) -> None:
+        self.ci = ClinicalIndication.objects.create(
+            r_code="R100.1", name="An illness", test_method="NGS"
         )
 
-        self.superpanel= SuperPanel.objects.create(
-            external_id=500,
-            panel_source="PanelApp",
-            panel_version=6
+        self.panel = Panel.objects.create(
+            external_id=500, panel_source="PanelApp", panel_version=6
+        )
+
+        self.superpanel = SuperPanel.objects.create(
+            external_id=500, panel_source="PanelApp", panel_version=6
         )
 
         self.ci_panel = ClinicalIndicationPanel.objects.create(
@@ -96,7 +88,7 @@ class TestFetchLatestTdVersion_OlderSuperPanel(TestCase):
             td_version="3",
             clinical_indication=self.ci,
             panel=self.panel,
-            current=True
+            current=True,
         )
 
         self.ci_superpanel = ClinicalIndicationSuperPanel.objects.create(
@@ -104,9 +96,9 @@ class TestFetchLatestTdVersion_OlderSuperPanel(TestCase):
             td_version="4",
             clinical_indication=self.ci,
             superpanel=self.superpanel,
-            current=True
+            current=True,
         )
-    
+
     def test_superpanel_older_than_panel(self):
         """
         Check that when the latest td version is in the SuperPanel,
@@ -124,16 +116,14 @@ class TestFetchLatestTdVersion_PanelOnly(TestCase):
     the td version in the panel-related data is correctly returned
     EXPECT: ClinicalIndicationPanel's td version is returned as correct
     """
+
     def setUp(self) -> None:
-        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
-                           name="An illness",
-                           test_method="NGS"
-                           )
+        self.ci = ClinicalIndication.objects.create(
+            r_code="R100.1", name="An illness", test_method="NGS"
+        )
 
         self.panel = Panel.objects.create(
-            external_id=500,
-            panel_source="PanelApp",
-            panel_version=6
+            external_id=500, panel_source="PanelApp", panel_version=6
         )
 
         self.ci_panel = ClinicalIndicationPanel.objects.create(
@@ -141,9 +131,9 @@ class TestFetchLatestTdVersion_PanelOnly(TestCase):
             td_version="3",
             clinical_indication=self.ci,
             panel=self.panel,
-            current=True
+            current=True,
         )
-    
+
     def test_only_panel_exists(self):
         """
         Check that when there is no SuperPanel data in the db,
@@ -161,16 +151,14 @@ class TestFetchLatestTdVersion_SuperPanelOnly(TestCase):
     the td version in the panel-related data is correctly returned
     EXPECT: ClinicalIndicationSuperPanel's td version is returned as correct
     """
+
     def setUp(self) -> None:
-        self.ci = ClinicalIndication.objects.create(r_code="R100.1",
-                           name="An illness",
-                           test_method="NGS"
-                           )
+        self.ci = ClinicalIndication.objects.create(
+            r_code="R100.1", name="An illness", test_method="NGS"
+        )
 
         self.panel = SuperPanel.objects.create(
-            external_id=500,
-            panel_source="PanelApp",
-            panel_version=6
+            external_id=500, panel_source="PanelApp", panel_version=6
         )
 
         self.ci_panel = ClinicalIndicationSuperPanel.objects.create(
@@ -178,9 +166,9 @@ class TestFetchLatestTdVersion_SuperPanelOnly(TestCase):
             td_version="3",
             clinical_indication=self.ci,
             superpanel=self.panel,
-            current=True
+            current=True,
         )
-    
+
     def test_only_panel_exists(self):
         """
         Check that when there is no Panel data in the db,
@@ -198,13 +186,14 @@ class TestFetchLatestTdVersion_NoDataAvailable(TestCase):
     a None value is returned
     EXPECT: td version returns as None
     """
+
     def setUp(self) -> None:
         pass
-    
+
     def test_only_panel_exists(self):
         latest_td = _fetch_latest_td_version()
 
         assert latest_td == None
 
 
-#TODO: test '_check_td_version_valid' if concerned
+# TODO: test '_check_td_version_valid' if concerned

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_data_into_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_data_into_db.py
@@ -18,7 +18,7 @@ from requests_app.models import (
     PanelRegion,
 )
 from requests_app.management.commands.utils import sortable_version
-from requests_app.management.commands._insert_panel import _insert_data_into_db
+from requests_app.management.commands._insert_panel import _insert_panel_data_into_db
 
 from .test_insert_gene import len_check_wrapper, value_check_wrapper
 
@@ -89,7 +89,7 @@ class TestInsertDataIntoDB(TestCase):
             ],
         )
 
-        _insert_data_into_db(mock_api, "PanelApp")
+        _insert_panel_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             ClinicalIndicationPanel.objects.all(), "clinical indication-panel", 1
@@ -162,7 +162,7 @@ class TestInsertDataIntoDB(TestCase):
             regions=[],
         )
 
-        _insert_data_into_db(mock_api, "PanelApp")
+        _insert_panel_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             ClinicalIndicationPanel.objects.all(), "clinical indication-panel", 2
@@ -226,7 +226,7 @@ class TestInsertDataIntoDB(TestCase):
             regions=[],
         )
 
-        _insert_data_into_db(mock_api, "PanelApp")
+        _insert_panel_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             ClinicalIndicationPanel.objects.all(), "ClinicalIndicationPanel", 2
@@ -290,7 +290,7 @@ class TestInsertDataIntoDB(TestCase):
             regions=[],
         )
 
-        _insert_data_into_db(mock_api, "PanelApp")
+        _insert_panel_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             Panel.objects.all(), "panel", 1

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_data_into_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_data_into_db.py
@@ -18,7 +18,7 @@ from requests_app.models import (
     PanelRegion,
 )
 from requests_app.management.commands.utils import sortable_version
-from requests_app.management.commands._insert_panel import insert_data_into_db
+from requests_app.management.commands._insert_panel import _insert_data_into_db
 
 from .test_insert_gene import len_check_wrapper, value_check_wrapper
 
@@ -89,7 +89,7 @@ class TestInsertDataIntoDB(TestCase):
             ],
         )
 
-        insert_data_into_db(mock_api, "PanelApp")
+        _insert_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             ClinicalIndicationPanel.objects.all(), "clinical indication-panel", 1
@@ -162,7 +162,7 @@ class TestInsertDataIntoDB(TestCase):
             regions=[],
         )
 
-        insert_data_into_db(mock_api, "PanelApp")
+        _insert_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             ClinicalIndicationPanel.objects.all(), "clinical indication-panel", 2
@@ -226,7 +226,7 @@ class TestInsertDataIntoDB(TestCase):
             regions=[],
         )
 
-        insert_data_into_db(mock_api, "PanelApp")
+        _insert_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             ClinicalIndicationPanel.objects.all(), "ClinicalIndicationPanel", 2
@@ -290,7 +290,7 @@ class TestInsertDataIntoDB(TestCase):
             regions=[],
         )
 
-        insert_data_into_db(mock_api, "PanelApp")
+        _insert_data_into_db(mock_api, "PanelApp")
 
         errors += len_check_wrapper(
             Panel.objects.all(), "panel", 1

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_panel_data_into_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_panel_data_into_db.py
@@ -1,5 +1,5 @@
 """
-Tested scenario `insert_data_into_db_function`
+Tested scenario `insert_panel_data_into_db_function`
 - core function of inserting panel and their metadata
 - flag previous and current clinical indication-panel link for review if panel name or panel version change in PanelApp API
 - nothing change if panel remains the same in PanelApp API

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_regions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_regions.py
@@ -2,16 +2,25 @@ from django.test import TestCase
 from django.db.models import QuerySet
 from django_mock_queries.query import MockSet, MockModel
 
-from requests_app.models import \
-    Panel, Confidence, ModeOfInheritance, \
-    Penetrance, ModeOfPathogenicity, Region, PanelRegion, VariantType, \
-    Haploinsufficiency, RequiredOverlap, Triplosensitivity
+from requests_app.models import (
+    Panel,
+    Confidence,
+    ModeOfInheritance,
+    Penetrance,
+    ModeOfPathogenicity,
+    Region,
+    PanelRegion,
+    VariantType,
+    Haploinsufficiency,
+    RequiredOverlap,
+    Triplosensitivity,
+)
 
-from requests_app.management.commands._insert_panel import \
-    _insert_regions
+from requests_app.management.commands._insert_panel import _insert_regions
 
 from requests_app.management.commands.panelapp import PanelClass
 from .test_insert_gene import len_check_wrapper, value_check_wrapper
+
 
 ## _insert_regions
 class TestInsertRegions_NewRegion(TestCase):
@@ -21,65 +30,58 @@ class TestInsertRegions_NewRegion(TestCase):
         No regions have been linked to it yet, at this point in the code
         """
         self.first_panel = Panel.objects.create(
-            external_id="162", \
-            panel_name="Severe microcephaly", \
-            panel_source="PanelApp", \
-            panel_version="4.31"
+            external_id="162",
+            panel_name="Severe microcephaly",
+            panel_source="PanelApp",
+            panel_version="4.31",
         )
-
 
     def test_new_panel_linked_to_acceptable_region(self):
         errors = []
 
-        # make one of the test inputs for the function        
+        # make one of the test inputs for the function
         test_panel = PanelClass(
-            id="162", 
-            name="Severe microcephaly", 
+            id="162",
+            name="Severe microcephaly",
             version="4.31",
             panel_source="PanelApp",
             genes=[],
-            regions=
-            [
-                {"gene_data": None,
-                "entity_type": "region",
-                "entity_name": "ISCA-37390-Loss",
-                "verbose_name": "5p15 terminal (Cri du chat syndrome) region Loss",
-                "confidence_level": "3",
-                "penetrance": None,
-                "mode_of_pathogenicity": None,
-                "haploinsufficiency_score": "3",
-                "triplosensitivity_score": "",
-                "required_overlap_percentage": 60,
-                "type_of_variants": "cnv_loss",
-                "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
-                "chromosome": "5",
-                "grch37_coordinates": None,
-                "grch38_coordinates": [
-                    37695,
-                    11347150
-                ],
+            regions=[
+                {
+                    "gene_data": None,
+                    "entity_type": "region",
+                    "entity_name": "ISCA-37390-Loss",
+                    "verbose_name": "5p15 terminal (Cri du chat syndrome) region Loss",
+                    "confidence_level": "3",
+                    "penetrance": None,
+                    "mode_of_pathogenicity": None,
+                    "haploinsufficiency_score": "3",
+                    "triplosensitivity_score": "",
+                    "required_overlap_percentage": 60,
+                    "type_of_variants": "cnv_loss",
+                    "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+                    "chromosome": "5",
+                    "grch37_coordinates": None,
+                    "grch38_coordinates": [37695, 11347150],
                 },
                 {
-                "gene_data": None,
-                "entity_type": "region",
-                "entity_name": "ISCA-37406-Loss",
-                "verbose_name": "16p13.3 region (includes CREBBP) Loss",
-                "confidence_level": "3",
-                "penetrance": None,
-                "mode_of_pathogenicity": None,
-                "haploinsufficiency_score": "3",
-                "triplosensitivity_score": "",
-                "required_overlap_percentage": 60,
-                "type_of_variants": "cnv_loss",
-                "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
-                "chromosome": "16",
-                "grch37_coordinates": None,
-                "grch38_coordinates": [
-                    3725055,
-                    3880120
-                    ] 
-                }
-            ]
+                    "gene_data": None,
+                    "entity_type": "region",
+                    "entity_name": "ISCA-37406-Loss",
+                    "verbose_name": "16p13.3 region (includes CREBBP) Loss",
+                    "confidence_level": "3",
+                    "penetrance": None,
+                    "mode_of_pathogenicity": None,
+                    "haploinsufficiency_score": "3",
+                    "triplosensitivity_score": "",
+                    "required_overlap_percentage": 60,
+                    "type_of_variants": "cnv_loss",
+                    "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+                    "chromosome": "16",
+                    "grch37_coordinates": None,
+                    "grch38_coordinates": [3725055, 3880120],
+                },
+            ],
         )
 
         _insert_regions(test_panel, self.first_panel)
@@ -96,17 +98,22 @@ class TestInsertRegions_NewRegion(TestCase):
         first_panel_regions = panel_regions[0]
         second_panel_regions = panel_regions[1]
 
-        errors += value_check_wrapper(first_panel_regions.panel, "first panel-region panel", 
-                              self.first_panel)
-        errors += value_check_wrapper(first_panel_regions.region, "first panel-region region", 
-                              regions[0])
-        errors += value_check_wrapper(second_panel_regions.panel, "second panel-region panel", 
-                              self.first_panel)
-        errors += value_check_wrapper(second_panel_regions.region, "second panel-region region", 
-                              regions[1])
+        errors += value_check_wrapper(
+            first_panel_regions.panel, "first panel-region panel", self.first_panel
+        )
+        errors += value_check_wrapper(
+            first_panel_regions.region, "first panel-region region", regions[0]
+        )
+        errors += value_check_wrapper(
+            second_panel_regions.panel, "second panel-region panel", self.first_panel
+        )
+        errors += value_check_wrapper(
+            second_panel_regions.region, "second panel-region region", regions[1]
+        )
 
         errors = "".join(errors)
         assert not errors, errors
+
 
 class TestInsertRegions_PreexistingRegion(TestCase):
     def setUp(self) -> None:
@@ -114,47 +121,32 @@ class TestInsertRegions_PreexistingRegion(TestCase):
         Scenario: a new panel has been made in the database
         No regions have been linked to it yet, at this point in the code
         One of the regions already exists in the database, emulating the situation
-        where a region exists on multiple panels 
+        where a region exists on multiple panels
         """
         self.first_panel = Panel.objects.create(
-            external_id="162", \
-            panel_name="Severe microcephaly", \
-            panel_source="PanelApp", \
-            panel_version="4.31"
+            external_id="162",
+            panel_name="Severe microcephaly",
+            panel_source="PanelApp",
+            panel_version="4.31",
         )
 
+        self.confidence = Confidence.objects.create(confidence_level=3)
 
-        self.confidence = Confidence.objects.create(
-            confidence_level=3
-        )
+        self.moi = ModeOfInheritance.objects.create(mode_of_inheritance="TEST VALUE")
 
-        self.moi = ModeOfInheritance.objects.create(
-            mode_of_inheritance="TEST VALUE"
-        )
+        self.mop = ModeOfPathogenicity.objects.create(mode_of_pathogenicity=None)
 
-        self.mop = ModeOfPathogenicity.objects.create(
-            mode_of_pathogenicity=None
-        )
-
-        self.variant_type = VariantType.objects.create(
-            variant_type="cnv_test"
-        )
+        self.variant_type = VariantType.objects.create(variant_type="cnv_test")
 
         self.haploinsufficiency = Haploinsufficiency.objects.create(
             haploinsufficiency=300
         )
 
-        self.overlap = RequiredOverlap.objects.create(
-            required_overlap=600
-        )
+        self.overlap = RequiredOverlap.objects.create(required_overlap=600)
 
-        self.penetrance = Penetrance.objects.create(
-            penetrance=None
-        )
+        self.penetrance = Penetrance.objects.create(penetrance=None)
 
-        self.triplosensitivity = Triplosensitivity.objects.create(
-            triplosensitivity = ""
-        )
+        self.triplosensitivity = Triplosensitivity.objects.create(triplosensitivity="")
 
         self.first_region = Region.objects.create(
             name="ISCA-37406-Loss",
@@ -172,63 +164,55 @@ class TestInsertRegions_PreexistingRegion(TestCase):
             overlap=self.overlap,
             penetrance_id=self.penetrance.id,
             triplo=self.triplosensitivity,
-            type="region"
+            type="region",
         )
 
-
     def test_new_panel_linked_to_pre_existing_region(self):
-
         errors = []
-        
-        # make one of the test inputs for the function        
+
+        # make one of the test inputs for the function
         test_panel = PanelClass(
-            id="162", 
-            name="Severe microcephaly", 
+            id="162",
+            name="Severe microcephaly",
             version="4.31",
             panel_source="PanelApp",
             genes=[],
-            regions=
-            [
-                {"gene_data": None,
-                "entity_type": "region",
-                "entity_name": "ISCA-37390-Loss",
-                "verbose_name": "5p15 terminal (Cri du chat syndrome) region Loss",
-                "confidence_level": "3",
-                "penetrance": "test_value",
-                "mode_of_pathogenicity": None,
-                "haploinsufficiency_score": "3",
-                "triplosensitivity_score": "test",
-                "required_overlap_percentage": 60,
-                "type_of_variants": "cnv_loss",
-                "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
-                "chromosome": "5",
-                "grch37_coordinates": None,
-                "grch38_coordinates": [
-                    37695,
-                    11347150
-                ],
+            regions=[
+                {
+                    "gene_data": None,
+                    "entity_type": "region",
+                    "entity_name": "ISCA-37390-Loss",
+                    "verbose_name": "5p15 terminal (Cri du chat syndrome) region Loss",
+                    "confidence_level": "3",
+                    "penetrance": "test_value",
+                    "mode_of_pathogenicity": None,
+                    "haploinsufficiency_score": "3",
+                    "triplosensitivity_score": "test",
+                    "required_overlap_percentage": 60,
+                    "type_of_variants": "cnv_loss",
+                    "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+                    "chromosome": "5",
+                    "grch37_coordinates": None,
+                    "grch38_coordinates": [37695, 11347150],
                 },
                 {
-                "gene_data": None,
-                "entity_type": "region",
-                "entity_name": "ISCA-37406-Loss",
-                "verbose_name": "16p13.3 region (includes CREBBP) Loss",
-                "confidence_level": "3",
-                "penetrance": None,
-                "mode_of_pathogenicity": None,
-                "haploinsufficiency_score": "300",
-                "triplosensitivity_score": "",
-                "required_overlap_percentage": 600,
-                "type_of_variants": "cnv_test",
-                "mode_of_inheritance": "TEST VALUE",
-                "chromosome": "16",
-                "grch37_coordinates": None,
-                "grch38_coordinates": [
-                    3725055,
-                    3880120
-                    ] 
-                }
-            ]
+                    "gene_data": None,
+                    "entity_type": "region",
+                    "entity_name": "ISCA-37406-Loss",
+                    "verbose_name": "16p13.3 region (includes CREBBP) Loss",
+                    "confidence_level": "3",
+                    "penetrance": None,
+                    "mode_of_pathogenicity": None,
+                    "haploinsufficiency_score": "300",
+                    "triplosensitivity_score": "",
+                    "required_overlap_percentage": 600,
+                    "type_of_variants": "cnv_test",
+                    "mode_of_inheritance": "TEST VALUE",
+                    "chromosome": "16",
+                    "grch37_coordinates": None,
+                    "grch38_coordinates": [3725055, 3880120],
+                },
+            ],
         )
 
         _insert_regions(test_panel, self.first_panel)
@@ -238,21 +222,24 @@ class TestInsertRegions_PreexistingRegion(TestCase):
         regions = Region.objects.all()
         errors += len_check_wrapper(regions, "regions", 2)
 
-        errors += value_check_wrapper(regions[0].name, "name of first region", 
-                              self.first_region.name)
+        errors += value_check_wrapper(
+            regions[0].name, "name of first region", self.first_region.name
+        )
         # the pre-populated value will show first
-        errors += value_check_wrapper(regions[1].name, "name of second region", 
-                              "ISCA-37390-Loss")
-
+        errors += value_check_wrapper(
+            regions[1].name, "name of second region", "ISCA-37390-Loss"
+        )
 
         # check that both regions are linked to the correct panel
         panel_regions = PanelRegion.objects.all()
         errors += len_check_wrapper(panel_regions, "panel-regions", 2)
-        errors += value_check_wrapper(panel_regions[0].panel, "first panel-regions' panel",
-                                       self.first_panel)
-        errors += value_check_wrapper(panel_regions[1].panel, "first panel-regions' panel",
-                                       self.first_panel)
-        
+        errors += value_check_wrapper(
+            panel_regions[0].panel, "first panel-regions' panel", self.first_panel
+        )
+        errors += value_check_wrapper(
+            panel_regions[1].panel, "first panel-regions' panel", self.first_panel
+        )
+
         errors = "".join(errors)
         assert not errors, errors
 
@@ -265,44 +252,29 @@ class TestInsertRegions_PreexistingLink(TestCase):
         where a panel is updated with region changes
         """
         self.first_panel = Panel.objects.create(
-            external_id="162", \
-            panel_name="Severe microcephaly", \
-            panel_source="PanelApp", \
-            panel_version="4.31"
+            external_id="162",
+            panel_name="Severe microcephaly",
+            panel_source="PanelApp",
+            panel_version="4.31",
         )
 
+        self.confidence = Confidence.objects.create(confidence_level=3)
 
-        self.confidence = Confidence.objects.create(
-            confidence_level=3
-        )
+        self.moi = ModeOfInheritance.objects.create(mode_of_inheritance="TEST VALUE")
 
-        self.moi = ModeOfInheritance.objects.create(
-            mode_of_inheritance="TEST VALUE"
-        )
+        self.mop = ModeOfPathogenicity.objects.create(mode_of_pathogenicity=None)
 
-        self.mop = ModeOfPathogenicity.objects.create(
-            mode_of_pathogenicity=None
-        )
-
-        self.variant_type = VariantType.objects.create(
-            variant_type="cnv_test"
-        )
+        self.variant_type = VariantType.objects.create(variant_type="cnv_test")
 
         self.haploinsufficiency = Haploinsufficiency.objects.create(
             haploinsufficiency=300
         )
 
-        self.overlap = RequiredOverlap.objects.create(
-            required_overlap=600
-        )
+        self.overlap = RequiredOverlap.objects.create(required_overlap=600)
 
-        self.penetrance = Penetrance.objects.create(
-            penetrance=None
-        )
+        self.penetrance = Penetrance.objects.create(penetrance=None)
 
-        self.triplosensitivity = Triplosensitivity.objects.create(
-            triplosensitivity = ""
-        )
+        self.triplosensitivity = Triplosensitivity.objects.create(triplosensitivity="")
 
         self.first_region = Region.objects.create(
             name="ISCA-37406-Loss",
@@ -320,70 +292,61 @@ class TestInsertRegions_PreexistingLink(TestCase):
             overlap=self.overlap,
             penetrance_id=self.penetrance.id,
             triplo=self.triplosensitivity,
-            type="region"
+            type="region",
         )
 
         self.first_panel_region_link = PanelRegion.objects.create(
             region=self.first_region,
             panel=self.first_panel,
-            justification="test_justification"
+            justification="test_justification",
         )
 
-
     def test_pre_existing_panel_region_link(self):
-
         errors = []
 
-        # make one of the test inputs for the function        
+        # make one of the test inputs for the function
         test_panel = PanelClass(
-            id="162", 
-            name="Severe microcephaly", 
+            id="162",
+            name="Severe microcephaly",
             version="4.31",
             panel_source="PanelApp",
             genes=[],
-            regions=
-            [
-                {"gene_data": None,
-                "entity_type": "region",
-                "entity_name": "ISCA-37390-Loss",
-                "verbose_name": "5p15 terminal (Cri du chat syndrome) region Loss",
-                "confidence_level": "3",
-                "penetrance": "test_value",
-                "mode_of_pathogenicity": None,
-                "haploinsufficiency_score": "3",
-                "triplosensitivity_score": "test",
-                "required_overlap_percentage": 60,
-                "type_of_variants": "cnv_loss",
-                "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
-                "chromosome": "5",
-                "grch37_coordinates": None,
-                "grch38_coordinates": [
-                    37695,
-                    11347150
-                ],
+            regions=[
+                {
+                    "gene_data": None,
+                    "entity_type": "region",
+                    "entity_name": "ISCA-37390-Loss",
+                    "verbose_name": "5p15 terminal (Cri du chat syndrome) region Loss",
+                    "confidence_level": "3",
+                    "penetrance": "test_value",
+                    "mode_of_pathogenicity": None,
+                    "haploinsufficiency_score": "3",
+                    "triplosensitivity_score": "test",
+                    "required_overlap_percentage": 60,
+                    "type_of_variants": "cnv_loss",
+                    "mode_of_inheritance": "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown",
+                    "chromosome": "5",
+                    "grch37_coordinates": None,
+                    "grch38_coordinates": [37695, 11347150],
                 },
                 {
-                "gene_data": None,
-                "entity_type": "region",
-                "entity_name": "ISCA-37406-Loss",
-                "verbose_name": "16p13.3 region (includes CREBBP) Loss",
-                "confidence_level": "3",
-                "penetrance": None,
-                "mode_of_pathogenicity": None,
-                "haploinsufficiency_score": "300",
-                "triplosensitivity_score": "",
-                "required_overlap_percentage": 600,
-                "type_of_variants": "cnv_test",
-                "mode_of_inheritance": "TEST VALUE",
-                "chromosome": "16",
-                "grch37_coordinates": None,
-                "grch38_coordinates": [
-                    3725055,
-                    3880120
-                    ] 
-                }
-            ]
-            
+                    "gene_data": None,
+                    "entity_type": "region",
+                    "entity_name": "ISCA-37406-Loss",
+                    "verbose_name": "16p13.3 region (includes CREBBP) Loss",
+                    "confidence_level": "3",
+                    "penetrance": None,
+                    "mode_of_pathogenicity": None,
+                    "haploinsufficiency_score": "300",
+                    "triplosensitivity_score": "",
+                    "required_overlap_percentage": 600,
+                    "type_of_variants": "cnv_test",
+                    "mode_of_inheritance": "TEST VALUE",
+                    "chromosome": "16",
+                    "grch37_coordinates": None,
+                    "grch38_coordinates": [3725055, 3880120],
+                },
+            ],
         )
 
         _insert_regions(test_panel, self.first_panel)
@@ -393,20 +356,23 @@ class TestInsertRegions_PreexistingLink(TestCase):
         regions = Region.objects.all()
 
         errors += len_check_wrapper(regions, "regions", 2)
-        errors += value_check_wrapper(regions[0].name, "name of first region",
-                                       self.first_region.name) # the pre-populated value will show first
-        errors += value_check_wrapper(regions[1].name, "name of second region",
-                                      "ISCA-37390-Loss")
-
+        errors += value_check_wrapper(
+            regions[0].name, "name of first region", self.first_region.name
+        )  # the pre-populated value will show first
+        errors += value_check_wrapper(
+            regions[1].name, "name of second region", "ISCA-37390-Loss"
+        )
 
         # check that both regions are linked to the correct panel
         # the first link in PanelRegion will be the one we made in set-up
         panel_regions = PanelRegion.objects.all()
         errors += len_check_wrapper(panel_regions, "panel-regions", 2)
-        errors += value_check_wrapper(panel_regions[0], "first panel-region", 
-                              self.first_panel_region_link)
-        errors += value_check_wrapper(panel_regions[1].panel, "second panel-region's panel", 
-                                      self.first_panel)
+        errors += value_check_wrapper(
+            panel_regions[0], "first panel-region", self.first_panel_region_link
+        )
+        errors += value_check_wrapper(
+            panel_regions[1].panel, "second panel-region's panel", self.first_panel
+        )
 
         errors = "".join(errors)
         assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_superpanel_into_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_superpanel_into_db.py
@@ -1,0 +1,441 @@
+"""
+Tested scenario `insert_superpanel_into_db_function`
+- core function of inserting SuperPanels, metadata, and links to children
+- flag previous and current clinical indication-panel link for review if 
+superpanel name or version change in PanelApp API
+- nothing changes if superpanel remains the same in PanelApp API
+
+
+- does not test for superpanel-gene changes - this is dealt with in `insert_gene`
+"""
+
+from django.test import TestCase
+import unittest
+from requests_app.management.commands.panelapp import PanelClass, SuperPanelClass
+from requests_app.models import (
+    Panel,
+    SuperPanel,
+    PanelSuperPanel,
+    ClinicalIndication,
+    ClinicalIndicationSuperPanel,
+    ClinicalIndicationSuperPanelHistory
+)
+from requests_app.management.commands.utils import sortable_version, normalize_version
+from requests_app.management.commands.history import History
+from requests_app.management.commands._insert_panel import _insert_superpanel_into_db
+
+from .test_insert_gene import len_check_wrapper, value_check_wrapper
+
+
+class TestInsertNewSuperpanelIntoDb(TestCase):
+    def setUp(self) -> None:
+        """
+        setup conditions for the test
+        """
+        # child-panels of our SuperPanel, made in advance
+        self.child_one = Panel.objects.create(
+            external_id="1",
+            panel_name="Rhabdo one",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.15")
+        )
+
+        self.child_two = Panel.objects.create(
+            external_id="2",
+            panel_name="Rhabdo_two",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.16")
+        )
+
+        self.first_clinical_indication = ClinicalIndication.objects.create(
+            r_code="R123",
+            name="Test clinical indication",
+            test_method="Test method",
+        )
+
+    def test_that_a_new_superpanel_is_made(
+        self,
+    ):
+        """
+        Test that the a brand new superpanel is inserted into the db,
+        and links formed with its child panels.        
+        """
+        errors = []
+
+        superpanel = SuperPanelClass(
+            id="1142",
+            name="Acute rhabdomyolyosis",
+            version="1.15",
+            panel_source="PanelApp",
+            genes=[],
+            regions=[],
+            child_panels=[]
+        )
+
+        child_panels=[self.child_one, self.child_two]
+
+        _insert_superpanel_into_db(superpanel, child_panels, "PanelApp")
+
+        # look at db changes
+        superpanel = SuperPanel.objects.all()
+        ci_superpanel = ClinicalIndicationSuperPanel.objects.all()
+        panel_superpanel = PanelSuperPanel.objects.all()
+
+        # a superpanel should be made and set to pending
+        errors += len_check_wrapper(
+            superpanel, "superpanel", 1
+        )
+        errors += value_check_wrapper(superpanel[0].external_id, "ext id", "1142")
+        errors += value_check_wrapper(superpanel[0].pending, "pending", False)
+
+        # there won't be a CI link because this is a brand new superpanel
+        errors += len_check_wrapper(
+            ci_superpanel, "clinical indication-superpanel", 0
+        )
+
+        # there should be links to child panels
+        errors += len_check_wrapper(
+            panel_superpanel, "panel-superpanel links", 2
+        )
+        errors += value_check_wrapper(panel_superpanel[0].panel,
+                                      "panel-superpanel Panel",
+                                      self.child_one)
+        errors += value_check_wrapper(panel_superpanel[1].panel,
+                                      "panel-superpanel Panel",
+                                      self.child_two)
+
+        assert not errors, errors
+
+
+class TestInsertSuperpanelVersionChange(TestCase):
+    """
+    Testing case when a superpanel has a version update
+    It should inherit the CI of the previous version,
+    and be set to Pending
+    """
+    def setUp(self) -> None:
+        """
+        setup conditions for the test
+        """
+        # child-panels of our SuperPanel, made in advance
+        self.child_one = Panel.objects.create(
+            external_id="1",
+            panel_name="Rhabdo one",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.15")
+        )
+
+        self.child_two = Panel.objects.create(
+            external_id="2",
+            panel_name="Rhabdo_two",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.16")
+        )
+        self.child_two.save()
+
+        self.first_clinical_indication = ClinicalIndication.objects.create(
+            r_code="R123",
+            name="Test clinical indication",
+            test_method="Test method",
+        )
+
+        self.old_superpanel = SuperPanel.objects.create(
+            external_id="1142",
+            panel_name="Acute rhabdomyolyosis",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.16")
+        )
+
+        self.ci = ClinicalIndication.objects.create(
+            r_code="Rtest",
+            name="test_CI",
+            test_method="NGS"
+        )
+
+        self.ci_old_superpanel_link = ClinicalIndicationSuperPanel.objects.create(
+            config_source="td",
+            td_version="5",
+            superpanel=self.old_superpanel,
+            clinical_indication=self.ci,
+            current=True
+        )
+
+        self.child_panels=[self.child_one, self.child_two]
+
+    def test_old_ci_superpanel_link_flagged_on_superpanel_version_change(
+        self,
+    ):
+        """
+        example scenario (superpanel version upgrade):
+        - first superpanel is already in the database
+        - in our test, we link it to a CI
+        - second superpanel comes in with the same external-id, but different version
+        - we expect the first superpanel-ci link to be flagged as pending
+        - and we expect a new, flagged link between second panel and first clinical indication
+        """
+        errors = []
+
+        new_superpanel = SuperPanelClass(
+            id="1142",
+            name="Acute rhabdomyolyosis",
+            version="1.20", # higher version
+            panel_source="PanelApp",
+            genes=[],
+            regions=[],
+            child_panels=[]
+        )
+
+        _insert_superpanel_into_db(new_superpanel, self.child_panels, "PanelApp")
+
+        # check what's in the db now
+        ci_superpanels = ClinicalIndicationSuperPanel.objects.all()
+        superpanels = SuperPanel.objects.all()
+        ci_superpanels_history = ClinicalIndicationSuperPanel.objects.all()
+
+        errors += len_check_wrapper(
+            ci_superpanels, "clinical indication-panel", 2
+        )
+        errors += len_check_wrapper(
+            superpanels, "superpanels", 2
+        )
+        errors += len_check_wrapper(
+            ci_superpanels_history, "ci-superpanel history", 2
+        )
+
+        errors += value_check_wrapper(
+            superpanels[1].panel_version, "second panel version", sortable_version("1.20")
+        )  # assert that the second panel version is the newer one
+
+        # Both CI-SuperPanel links should now be pending=True,
+        # awaiting review
+        errors += value_check_wrapper(
+            ci_superpanels[0].superpanel,
+            "Superpanel in first link",
+            self.old_superpanel
+        ) # just to ascertain that the old superpanel is first in QuerySet
+        errors += value_check_wrapper(
+            ci_superpanels[0].pending,
+            "first CI-superpanel pending",
+            True
+        )
+        errors += value_check_wrapper(
+            ci_superpanels[0].current,
+            "first CI-superpanel current",
+            False
+        )
+
+        errors += value_check_wrapper(
+            ci_superpanels[1].pending,
+            "second clinical indication-superpanel pending",
+            True
+        )
+        errors += value_check_wrapper(
+            ci_superpanels[1].current,
+            "second CI-superpanel current",
+            True
+        )      
+
+        assert not errors, errors
+
+
+class TestInsertSuperpanelNameChange(TestCase):
+    """
+    Testing case when a superpanel has a name update
+    It should inherit the CI of the previous version,
+    and be set to Pending
+    """
+    def setUp(self) -> None:
+        """
+        setup conditions for the test
+        """
+        # child-panels of our SuperPanel, made in advance
+        self.child_one = Panel.objects.create(
+            external_id="1",
+            panel_name="Rhabdo one",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.15")
+        )
+
+        self.child_two = Panel.objects.create(
+            external_id="2",
+            panel_name="Rhabdo_two",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.16")
+        )
+        self.child_two.save()
+
+        self.first_clinical_indication = ClinicalIndication.objects.create(
+            r_code="R123",
+            name="Test clinical indication",
+            test_method="Test method",
+        )
+
+        self.old_superpanel = SuperPanel.objects.create(
+            external_id="1142",
+            panel_name="Acute rhabdomyolyosis",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.16")
+        )
+
+        self.ci = ClinicalIndication.objects.create(
+            r_code="Rtest",
+            name="test_CI",
+            test_method="NGS"
+        )
+
+        self.ci_old_superpanel_link = ClinicalIndicationSuperPanel.objects.create(
+            config_source="td",
+            td_version="5",
+            superpanel=self.old_superpanel,
+            clinical_indication=self.ci,
+            current=True
+        )
+
+        self.child_panels=[self.child_one, self.child_two]
+
+
+    def test_previous_ci_superpanel_flagged_on_superpanel_name_change(
+        self,
+    ):
+        """
+        example scenario (superpanel version upgrade):
+        - first superpanel and first clinical indication are already linked in the database
+        - second panel comes in with the same external-id, but different panel name
+        EXPECT:
+        - first superpanel and CI have their link flagged for review
+        - a new link is made between second superpanel and first clinical indication for review
+        """
+        errors = []
+
+        superpanel_input = SuperPanelClass(
+            id="1142",
+            name="Acute rhabdomyolosis with a different name",  # note the different name
+            version="1.16", 
+            panel_source="PanelApp",
+            genes=[],
+            regions=[]
+        )
+
+        _insert_superpanel_into_db(superpanel_input, self.child_panels, "PanelApp")
+
+        ci_superpanels = ClinicalIndicationSuperPanel.objects.all()
+        superpanels = SuperPanel.objects.all()
+
+        errors += len_check_wrapper(
+            ci_superpanels, "ClinicalIndicationSuperpanel", 2
+        )  # assert that there is a new clinical indication-panel
+
+        errors += value_check_wrapper(
+            ci_superpanels[0].pending,
+            "first clinical indication-panel pending",
+            True,
+        )  # assert that the first clinical indication-panel is flagged for review
+        errors += value_check_wrapper(
+            ci_superpanels[1].pending,
+            "second clinical indication-panel pending",
+            True,
+        )  # assert that the second clinical indication-panel is flagged for review
+
+
+        errors += value_check_wrapper(
+            superpanels[1].panel_name,
+            "second panel name",
+            "Acute rhabdomyolosis with a different name",
+        )  # assert second panel name is "Acute rhabdomyolosis with a different name"
+
+        assert not errors, errors
+
+
+class TestInsertSuperpanelUnchanged(TestCase):
+    """
+    Testing case when a superpanel hasn't changed in PanelApp 
+    since the last Eris update.
+    EXPECT: SuperPanel not added to the db.
+    """
+    def setUp(self) -> None:
+        """
+        setup conditions for the test
+        """
+        # child-panels of our SuperPanel, made in advance
+        self.child_one = Panel.objects.create(
+            external_id="1",
+            panel_name="Rhabdo one",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.15")
+        )
+
+        self.child_two = Panel.objects.create(
+            external_id="2",
+            panel_name="Rhabdo_two",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.16")
+        )
+
+        self.first_clinical_indication = ClinicalIndication.objects.create(
+            r_code="R123",
+            name="Test clinical indication",
+            test_method="Test method",
+        )
+
+        self.old_superpanel = SuperPanel.objects.create(
+            external_id="1142",
+            panel_name="Acute rhabdomyolyosis",
+            panel_source="PanelApp",
+            panel_version=sortable_version("1.16")
+        )
+
+        self.ci = ClinicalIndication.objects.create(
+            r_code="Rtest",
+            name="test_CI",
+            test_method="NGS"
+        )
+
+        self.ci_old_superpanel_link = ClinicalIndicationSuperPanel.objects.create(
+            config_source="td",
+            td_version="5",
+            superpanel=self.old_superpanel,
+            clinical_indication=self.ci,
+            current=True
+        )
+
+        self.child_panels=[self.child_one, self.child_two]
+
+
+    def test_panel_unchanged_in_panelapp_api(
+        self,
+    ):
+        """
+        SCENARIO: superpanel unchanged between uploads in PanelApp API
+        EXPECT: no changes in the database
+        """
+        errors = []
+
+        superpanel_input = SuperPanelClass(
+            id="1142",
+            name="Acute rhabdomyolyosis",
+            version=sortable_version("1.16"),
+            panel_source="PanelApp",
+            genes=[],
+            regions=[]
+            #child_panels=[child_one, child_two]
+        )
+
+        _insert_superpanel_into_db(superpanel_input, self.child_panels, "PanelApp")
+
+        superpanels = SuperPanel.objects.all()
+        history = ClinicalIndicationSuperPanelHistory.objects.all()
+
+        errors += len_check_wrapper(
+            superpanels, "superpanel", 1
+        )  # assert only one SuperPanel objects
+
+        errors += len_check_wrapper(
+            history, "history", 0) # didn't make a history/link with CI
+
+        errors += value_check_wrapper(
+            superpanels[0].panel_name, "superpanel name", "Acute rhabdomyolyosis"
+        )  # assert nothing has changed to the existing panel
+
+        self.assertEqual(self.old_superpanel, superpanels[0])
+
+        assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_superpanel_into_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_superpanel_into_db.py
@@ -18,7 +18,7 @@ from requests_app.models import (
     PanelSuperPanel,
     ClinicalIndication,
     ClinicalIndicationSuperPanel,
-    ClinicalIndicationSuperPanelHistory
+    ClinicalIndicationSuperPanelHistory,
 )
 from requests_app.management.commands.utils import sortable_version, normalize_version
 from requests_app.management.commands.history import History
@@ -37,14 +37,14 @@ class TestInsertNewSuperpanelIntoDb(TestCase):
             external_id="1",
             panel_name="Rhabdo one",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.15")
+            panel_version=sortable_version("1.15"),
         )
 
         self.child_two = Panel.objects.create(
             external_id="2",
             panel_name="Rhabdo_two",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.16")
+            panel_version=sortable_version("1.16"),
         )
 
         self.first_clinical_indication = ClinicalIndication.objects.create(
@@ -58,7 +58,7 @@ class TestInsertNewSuperpanelIntoDb(TestCase):
     ):
         """
         Test that the a brand new superpanel is inserted into the db,
-        and links formed with its child panels.        
+        and links formed with its child panels.
         """
         errors = []
 
@@ -69,10 +69,10 @@ class TestInsertNewSuperpanelIntoDb(TestCase):
             panel_source="PanelApp",
             genes=[],
             regions=[],
-            child_panels=[]
+            child_panels=[],
         )
 
-        child_panels=[self.child_one, self.child_two]
+        child_panels = [self.child_one, self.child_two]
 
         _insert_superpanel_into_db(superpanel, child_panels, "PanelApp")
 
@@ -82,27 +82,21 @@ class TestInsertNewSuperpanelIntoDb(TestCase):
         panel_superpanel = PanelSuperPanel.objects.all()
 
         # a superpanel should be made and set to pending
-        errors += len_check_wrapper(
-            superpanel, "superpanel", 1
-        )
+        errors += len_check_wrapper(superpanel, "superpanel", 1)
         errors += value_check_wrapper(superpanel[0].external_id, "ext id", "1142")
         errors += value_check_wrapper(superpanel[0].pending, "pending", False)
 
         # there won't be a CI link because this is a brand new superpanel
-        errors += len_check_wrapper(
-            ci_superpanel, "clinical indication-superpanel", 0
-        )
+        errors += len_check_wrapper(ci_superpanel, "clinical indication-superpanel", 0)
 
         # there should be links to child panels
-        errors += len_check_wrapper(
-            panel_superpanel, "panel-superpanel links", 2
+        errors += len_check_wrapper(panel_superpanel, "panel-superpanel links", 2)
+        errors += value_check_wrapper(
+            panel_superpanel[0].panel, "panel-superpanel Panel", self.child_one
         )
-        errors += value_check_wrapper(panel_superpanel[0].panel,
-                                      "panel-superpanel Panel",
-                                      self.child_one)
-        errors += value_check_wrapper(panel_superpanel[1].panel,
-                                      "panel-superpanel Panel",
-                                      self.child_two)
+        errors += value_check_wrapper(
+            panel_superpanel[1].panel, "panel-superpanel Panel", self.child_two
+        )
 
         assert not errors, errors
 
@@ -113,6 +107,7 @@ class TestInsertSuperpanelVersionChange(TestCase):
     It should inherit the CI of the previous version,
     and be set to Pending
     """
+
     def setUp(self) -> None:
         """
         setup conditions for the test
@@ -122,14 +117,14 @@ class TestInsertSuperpanelVersionChange(TestCase):
             external_id="1",
             panel_name="Rhabdo one",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.15")
+            panel_version=sortable_version("1.15"),
         )
 
         self.child_two = Panel.objects.create(
             external_id="2",
             panel_name="Rhabdo_two",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.16")
+            panel_version=sortable_version("1.16"),
         )
         self.child_two.save()
 
@@ -143,13 +138,11 @@ class TestInsertSuperpanelVersionChange(TestCase):
             external_id="1142",
             panel_name="Acute rhabdomyolyosis",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.16")
+            panel_version=sortable_version("1.16"),
         )
 
         self.ci = ClinicalIndication.objects.create(
-            r_code="Rtest",
-            name="test_CI",
-            test_method="NGS"
+            r_code="Rtest", name="test_CI", test_method="NGS"
         )
 
         self.ci_old_superpanel_link = ClinicalIndicationSuperPanel.objects.create(
@@ -157,10 +150,10 @@ class TestInsertSuperpanelVersionChange(TestCase):
             td_version="5",
             superpanel=self.old_superpanel,
             clinical_indication=self.ci,
-            current=True
+            current=True,
         )
 
-        self.child_panels=[self.child_one, self.child_two]
+        self.child_panels = [self.child_one, self.child_two]
 
     def test_old_ci_superpanel_link_flagged_on_superpanel_version_change(
         self,
@@ -178,11 +171,11 @@ class TestInsertSuperpanelVersionChange(TestCase):
         new_superpanel = SuperPanelClass(
             id="1142",
             name="Acute rhabdomyolyosis",
-            version="1.20", # higher version
+            version="1.20",  # higher version
             panel_source="PanelApp",
             genes=[],
             regions=[],
-            child_panels=[]
+            child_panels=[],
         )
 
         _insert_superpanel_into_db(new_superpanel, self.child_panels, "PanelApp")
@@ -192,18 +185,14 @@ class TestInsertSuperpanelVersionChange(TestCase):
         superpanels = SuperPanel.objects.all()
         ci_superpanels_history = ClinicalIndicationSuperPanel.objects.all()
 
-        errors += len_check_wrapper(
-            ci_superpanels, "clinical indication-panel", 2
-        )
-        errors += len_check_wrapper(
-            superpanels, "superpanels", 2
-        )
-        errors += len_check_wrapper(
-            ci_superpanels_history, "ci-superpanel history", 2
-        )
+        errors += len_check_wrapper(ci_superpanels, "clinical indication-panel", 2)
+        errors += len_check_wrapper(superpanels, "superpanels", 2)
+        errors += len_check_wrapper(ci_superpanels_history, "ci-superpanel history", 2)
 
         errors += value_check_wrapper(
-            superpanels[1].panel_version, "second panel version", sortable_version("1.20")
+            superpanels[1].panel_version,
+            "second panel version",
+            sortable_version("1.20"),
         )  # assert that the second panel version is the newer one
 
         # Both CI-SuperPanel links should now be pending=True,
@@ -211,29 +200,23 @@ class TestInsertSuperpanelVersionChange(TestCase):
         errors += value_check_wrapper(
             ci_superpanels[0].superpanel,
             "Superpanel in first link",
-            self.old_superpanel
-        ) # just to ascertain that the old superpanel is first in QuerySet
+            self.old_superpanel,
+        )  # just to ascertain that the old superpanel is first in QuerySet
         errors += value_check_wrapper(
-            ci_superpanels[0].pending,
-            "first CI-superpanel pending",
-            True
+            ci_superpanels[0].pending, "first CI-superpanel pending", True
         )
         errors += value_check_wrapper(
-            ci_superpanels[0].current,
-            "first CI-superpanel current",
-            False
+            ci_superpanels[0].current, "first CI-superpanel current", False
         )
 
         errors += value_check_wrapper(
             ci_superpanels[1].pending,
             "second clinical indication-superpanel pending",
-            True
+            True,
         )
         errors += value_check_wrapper(
-            ci_superpanels[1].current,
-            "second CI-superpanel current",
-            True
-        )      
+            ci_superpanels[1].current, "second CI-superpanel current", True
+        )
 
         assert not errors, errors
 
@@ -244,6 +227,7 @@ class TestInsertSuperpanelNameChange(TestCase):
     It should inherit the CI of the previous version,
     and be set to Pending
     """
+
     def setUp(self) -> None:
         """
         setup conditions for the test
@@ -253,14 +237,14 @@ class TestInsertSuperpanelNameChange(TestCase):
             external_id="1",
             panel_name="Rhabdo one",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.15")
+            panel_version=sortable_version("1.15"),
         )
 
         self.child_two = Panel.objects.create(
             external_id="2",
             panel_name="Rhabdo_two",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.16")
+            panel_version=sortable_version("1.16"),
         )
         self.child_two.save()
 
@@ -274,13 +258,11 @@ class TestInsertSuperpanelNameChange(TestCase):
             external_id="1142",
             panel_name="Acute rhabdomyolyosis",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.16")
+            panel_version=sortable_version("1.16"),
         )
 
         self.ci = ClinicalIndication.objects.create(
-            r_code="Rtest",
-            name="test_CI",
-            test_method="NGS"
+            r_code="Rtest", name="test_CI", test_method="NGS"
         )
 
         self.ci_old_superpanel_link = ClinicalIndicationSuperPanel.objects.create(
@@ -288,11 +270,10 @@ class TestInsertSuperpanelNameChange(TestCase):
             td_version="5",
             superpanel=self.old_superpanel,
             clinical_indication=self.ci,
-            current=True
+            current=True,
         )
 
-        self.child_panels=[self.child_one, self.child_two]
-
+        self.child_panels = [self.child_one, self.child_two]
 
     def test_previous_ci_superpanel_flagged_on_superpanel_name_change(
         self,
@@ -310,10 +291,10 @@ class TestInsertSuperpanelNameChange(TestCase):
         superpanel_input = SuperPanelClass(
             id="1142",
             name="Acute rhabdomyolosis with a different name",  # note the different name
-            version="1.16", 
+            version="1.16",
             panel_source="PanelApp",
             genes=[],
-            regions=[]
+            regions=[],
         )
 
         _insert_superpanel_into_db(superpanel_input, self.child_panels, "PanelApp")
@@ -336,7 +317,6 @@ class TestInsertSuperpanelNameChange(TestCase):
             True,
         )  # assert that the second clinical indication-panel is flagged for review
 
-
         errors += value_check_wrapper(
             superpanels[1].panel_name,
             "second panel name",
@@ -348,10 +328,11 @@ class TestInsertSuperpanelNameChange(TestCase):
 
 class TestInsertSuperpanelUnchanged(TestCase):
     """
-    Testing case when a superpanel hasn't changed in PanelApp 
+    Testing case when a superpanel hasn't changed in PanelApp
     since the last Eris update.
     EXPECT: SuperPanel not added to the db.
     """
+
     def setUp(self) -> None:
         """
         setup conditions for the test
@@ -361,14 +342,14 @@ class TestInsertSuperpanelUnchanged(TestCase):
             external_id="1",
             panel_name="Rhabdo one",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.15")
+            panel_version=sortable_version("1.15"),
         )
 
         self.child_two = Panel.objects.create(
             external_id="2",
             panel_name="Rhabdo_two",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.16")
+            panel_version=sortable_version("1.16"),
         )
 
         self.first_clinical_indication = ClinicalIndication.objects.create(
@@ -381,13 +362,11 @@ class TestInsertSuperpanelUnchanged(TestCase):
             external_id="1142",
             panel_name="Acute rhabdomyolyosis",
             panel_source="PanelApp",
-            panel_version=sortable_version("1.16")
+            panel_version=sortable_version("1.16"),
         )
 
         self.ci = ClinicalIndication.objects.create(
-            r_code="Rtest",
-            name="test_CI",
-            test_method="NGS"
+            r_code="Rtest", name="test_CI", test_method="NGS"
         )
 
         self.ci_old_superpanel_link = ClinicalIndicationSuperPanel.objects.create(
@@ -395,11 +374,10 @@ class TestInsertSuperpanelUnchanged(TestCase):
             td_version="5",
             superpanel=self.old_superpanel,
             clinical_indication=self.ci,
-            current=True
+            current=True,
         )
 
-        self.child_panels=[self.child_one, self.child_two]
-
+        self.child_panels = [self.child_one, self.child_two]
 
     def test_panel_unchanged_in_panelapp_api(
         self,
@@ -417,7 +395,7 @@ class TestInsertSuperpanelUnchanged(TestCase):
             panel_source="PanelApp",
             genes=[],
             regions=[]
-            #child_panels=[child_one, child_two]
+            # child_panels=[child_one, child_two]
         )
 
         _insert_superpanel_into_db(superpanel_input, self.child_panels, "PanelApp")
@@ -430,7 +408,8 @@ class TestInsertSuperpanelUnchanged(TestCase):
         )  # assert only one SuperPanel objects
 
         errors += len_check_wrapper(
-            history, "history", 0) # didn't make a history/link with CI
+            history, "history", 0
+        )  # didn't make a history/link with CI
 
         errors += value_check_wrapper(
             superpanels[0].panel_name, "superpanel name", "Acute rhabdomyolyosis"

--- a/tests/tests_requests_app/test_management/test_commands/test_panelapp/test_superpanelclass.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_panelapp/test_superpanelclass.py
@@ -121,23 +121,122 @@ class TestSuperPanelClass(TestCase):
             "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss"
         assert first_panels_regions[0]["type_of_variants"] =="cnv_loss"
 
-    def test_multiple_genes_multiple_panels(self):
+    def test_gene_and_region_from_same_panel(self):
         """
         A situation where some panels and genes are from the same panel.
-        EXPECT: panels and genes from the same panel should append correctly 
+        EXPECT: 1 gene and 1 region from the same panel should append correctly 
         to the same, single PanelClass object.
         """
-        #TODO: write
-        pass
+        json_response = mocked_requests_get_superpanel(
+            "testing_files/panelapp_api_mocks/superpanel_api_example_gene_region_same_panel.json"
+        )
+        superpanel = SuperPanelClass(**json_response)
+        component_panels = superpanel.create_component_panels(superpanel.genes,
+                                                              superpanel.regions)
+        
+        # our test data contains only 2 regions, and these are both for the same panel
+        # the genes are removed from the test data so shouldn't affect anything
+        assert len(component_panels) == 1
+
+        assert len(component_panels[0].genes) == 1
+        assert len(component_panels[0].regions) == 1
+
+        first_panel = component_panels[0]
+        assert first_panel.id == 79
+        assert first_panel.name == "Paediatric motor neuronopathies"
+        assert first_panel.version == "3.4"
+        assert first_panel.panel_source == "PanelApp"
+
+        first_panel_genes = first_panel.genes
+        assert len(first_panel_genes) == 1
+        assert first_panel_genes[0]["gene_data"]["hgnc_id"] == "HGNC:735"
+        assert first_panel_genes[0]["gene_data"]["gene_name"] == \
+            "N-acylsphingosine amidohydrolase 1"
+
+        first_panels_regions = component_panels[0].regions
+        assert first_panels_regions[0]["entity_name"] == "ISCA-37404-Loss"
+        assert first_panels_regions[0]["verbose_name"] == \
+            "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss"
+        assert first_panels_regions[0]["type_of_variants"] == "cnv_loss"
 
     def test_gene_occurs_in_more_than_one_panel(self):
-        #TODO: write
-        pass
+        """
+        A situation where a gene appears in TWO subpanels
+        EXPECT: gene to be attributed to both panels, with info such as MOI 
+        separated out correctly
+        """
+        json_response = mocked_requests_get_superpanel(
+            "testing_files/panelapp_api_mocks/superpanel_api_example_one_gene_two_panels.json"
+        )
+        superpanel = SuperPanelClass(**json_response)
+        component_panels = superpanel.create_component_panels(superpanel.genes,
+                                                              superpanel.regions)
+        
+        assert len(component_panels) == 2
+
+        first_panel = component_panels[0]
+        assert first_panel.id == 225
+        assert first_panel.name == "Congenital myopathy"
+        assert first_panel.version == "4.31"
+        assert first_panel.panel_source == "PanelApp"
+
+        first_panel_genes = first_panel.genes
+        assert len(first_panel_genes) == 1
+        assert first_panel_genes[0]["gene_data"]["hgnc_id"] == "HGNC:3756"
+        assert first_panel_genes[0]["gene_data"]["gene_name"] == \
+            "filamin C"
+
+        second_panel = component_panels[1]
+        assert second_panel.id == 185
+        assert second_panel.name == \
+            "Limb girdle muscular dystrophies, myofibrillar myopathies and distal myopathies"
+        assert second_panel.version == "4.22"
+        assert second_panel.panel_source == "PanelApp"
+
+        second_panel_genes = second_panel.genes
+        assert len(second_panel_genes) == 1
+        assert second_panel_genes[0]["gene_data"]["hgnc_id"] == "HGNC:3756"
+        assert second_panel_genes[0]["gene_data"]["gene_name"] == \
+            "filamin C"
+
 
     def test_region_occurs_in_more_than_one_panel(self):
-        #TODO: write
-        pass
+        """
+        A situation where a region appears in TWO subpanels
+        EXPECT: region to be attributed to both panels, with info such as MOI 
+        separated out correctly
+        NOTE that the example regions file here was made by duplicating a region
+         from 'superpanel_api_example_one_gene_two_panels.json; and then
+        changing the panel in the JSON, while the other files were just made 
+        by deleting sections of 'real' API calls
+        """
+        json_response = mocked_requests_get_superpanel(
+            "testing_files/panelapp_api_mocks/superpanel_api_example_one_region_two_panels.json"
+        )
+        superpanel = SuperPanelClass(**json_response)
+        component_panels = superpanel.create_component_panels(superpanel.genes,
+                                                              superpanel.regions)
+        
+        assert len(component_panels) == 2
 
-    def test_region_and_gene_occurs_in_more_than_one_panel(self):
-        #TODO: write
-        pass
+        first_panel = component_panels[0]
+        assert first_panel.id == 79
+        assert first_panel.name == "Paediatric motor neuronopathies"
+        assert first_panel.version == "3.4"
+        assert first_panel.panel_source == "PanelApp"
+
+        first_panel_regions = first_panel.regions
+        assert len(first_panel_regions) == 1
+        assert first_panel_regions[0]["entity_name"] == "ISCA-37404-Loss"
+
+        second_panel = component_panels[1]
+        assert second_panel.id == 100
+        assert second_panel.name == \
+            "Other motor neuronopathies"
+        assert second_panel.version == "3.6"
+        assert second_panel.panel_source == "PanelApp"
+
+        second_panel_regions = second_panel.regions
+        assert len(second_panel_regions) == 1
+        assert second_panel_regions[0]["entity_name"] == "ISCA-37404-Loss"
+    

--- a/tests/tests_requests_app/test_management/test_commands/test_panelapp/test_superpanelclass.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_panelapp/test_superpanelclass.py
@@ -5,8 +5,7 @@ import numpy as np
 import json
 
 
-from requests_app.management.commands.panelapp import \
-    SuperPanelClass
+from requests_app.management.commands.panelapp import SuperPanelClass
 
 
 def returns_example_superpanel():
@@ -14,9 +13,9 @@ def returns_example_superpanel():
     Calls a known API endpoint for a superpanel
     and returns response.json()
     """
-    api_url="https://panelapp.genomicsengland.co.uk/api/v1/panels/"
-    panel_num="465"
-    version="19.155"
+    api_url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/"
+    panel_num = "465"
+    version = "19.155"
     panel_url = f"{api_url}{panel_num}/?version={version}&format=json"
     response = requests.get(panel_url)
     return response.json()
@@ -38,13 +37,14 @@ def mocked_requests_get_superpanel(filename):
 class TestSuperPanelClass(TestCase):
     """
     Tests for superpanel parsing.
-    Trying out scenarios with multiple genes per panel, multiple regions per panel, 
+    Trying out scenarios with multiple genes per panel, multiple regions per panel,
     and a more complex scenario, with multiple panels and regions for multiple panels.
     """
+
     def test_basic_values_parse(self):
         """
         Check that basic SuperPanel string values, such as ID, are parsed correctly
-        """ 
+        """
         # mocked-out API call
         json_response = mocked_requests_get_superpanel(
             "testing_files/panelapp_api_mocks/superpanel_api_example_most_genes_removed.json"
@@ -67,9 +67,10 @@ class TestSuperPanelClass(TestCase):
         )
         superpanel = SuperPanelClass(**json_response)
 
-        component_panels = superpanel.create_component_panels(superpanel.genes,
-                                                              superpanel.regions)
-        
+        component_panels = superpanel.create_component_panels(
+            superpanel.genes, superpanel.regions
+        )
+
         # our test data contains only 2 genes, and these are both for the same panel
         # there are no regions in the test data
         assert len(component_panels) == 1
@@ -85,7 +86,10 @@ class TestSuperPanelClass(TestCase):
 
         first_panels_genes = component_panels[0].genes
         assert first_panels_genes[0]["gene_data"]["hgnc_id"] == "HGNC:21497"
-        assert first_panels_genes[0]["gene_data"]["gene_name"] == "acyl-CoA dehydrogenase family member 9"
+        assert (
+            first_panels_genes[0]["gene_data"]["gene_name"]
+            == "acyl-CoA dehydrogenase family member 9"
+        )
 
     def test_multiple_regions_one_panel(self):
         """
@@ -98,9 +102,10 @@ class TestSuperPanelClass(TestCase):
         )
         superpanel = SuperPanelClass(**json_response)
 
-        component_panels = superpanel.create_component_panels(superpanel.genes,
-                                                              superpanel.regions)
-        
+        component_panels = superpanel.create_component_panels(
+            superpanel.genes, superpanel.regions
+        )
+
         # our test data contains only 2 regions, and these are both for the same panel
         # the genes are removed from the test data so shouldn't affect anything
         assert len(component_panels) == 1
@@ -117,23 +122,26 @@ class TestSuperPanelClass(TestCase):
 
         first_panels_regions = component_panels[0].regions
         assert first_panels_regions[0]["entity_name"] == "ISCA-37404-Loss"
-        assert first_panels_regions[0]["verbose_name"] == \
-            "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss"
-        assert first_panels_regions[0]["type_of_variants"] =="cnv_loss"
+        assert (
+            first_panels_regions[0]["verbose_name"]
+            == "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss"
+        )
+        assert first_panels_regions[0]["type_of_variants"] == "cnv_loss"
 
     def test_gene_and_region_from_same_panel(self):
         """
         A situation where some panels and genes are from the same panel.
-        EXPECT: 1 gene and 1 region from the same panel should append correctly 
+        EXPECT: 1 gene and 1 region from the same panel should append correctly
         to the same, single PanelClass object.
         """
         json_response = mocked_requests_get_superpanel(
             "testing_files/panelapp_api_mocks/superpanel_api_example_gene_region_same_panel.json"
         )
         superpanel = SuperPanelClass(**json_response)
-        component_panels = superpanel.create_component_panels(superpanel.genes,
-                                                              superpanel.regions)
-        
+        component_panels = superpanel.create_component_panels(
+            superpanel.genes, superpanel.regions
+        )
+
         # our test data contains only 2 regions, and these are both for the same panel
         # the genes are removed from the test data so shouldn't affect anything
         assert len(component_panels) == 1
@@ -150,28 +158,33 @@ class TestSuperPanelClass(TestCase):
         first_panel_genes = first_panel.genes
         assert len(first_panel_genes) == 1
         assert first_panel_genes[0]["gene_data"]["hgnc_id"] == "HGNC:735"
-        assert first_panel_genes[0]["gene_data"]["gene_name"] == \
-            "N-acylsphingosine amidohydrolase 1"
+        assert (
+            first_panel_genes[0]["gene_data"]["gene_name"]
+            == "N-acylsphingosine amidohydrolase 1"
+        )
 
         first_panels_regions = component_panels[0].regions
         assert first_panels_regions[0]["entity_name"] == "ISCA-37404-Loss"
-        assert first_panels_regions[0]["verbose_name"] == \
-            "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss"
+        assert (
+            first_panels_regions[0]["verbose_name"]
+            == "15q11q13 recurrent (PWS/AS) region (BP1-BP3, Class 1) Loss"
+        )
         assert first_panels_regions[0]["type_of_variants"] == "cnv_loss"
 
     def test_gene_occurs_in_more_than_one_panel(self):
         """
         A situation where a gene appears in TWO subpanels
-        EXPECT: gene to be attributed to both panels, with info such as MOI 
+        EXPECT: gene to be attributed to both panels, with info such as MOI
         separated out correctly
         """
         json_response = mocked_requests_get_superpanel(
             "testing_files/panelapp_api_mocks/superpanel_api_example_one_gene_two_panels.json"
         )
         superpanel = SuperPanelClass(**json_response)
-        component_panels = superpanel.create_component_panels(superpanel.genes,
-                                                              superpanel.regions)
-        
+        component_panels = superpanel.create_component_panels(
+            superpanel.genes, superpanel.regions
+        )
+
         assert len(component_panels) == 2
 
         first_panel = component_panels[0]
@@ -183,40 +196,40 @@ class TestSuperPanelClass(TestCase):
         first_panel_genes = first_panel.genes
         assert len(first_panel_genes) == 1
         assert first_panel_genes[0]["gene_data"]["hgnc_id"] == "HGNC:3756"
-        assert first_panel_genes[0]["gene_data"]["gene_name"] == \
-            "filamin C"
+        assert first_panel_genes[0]["gene_data"]["gene_name"] == "filamin C"
 
         second_panel = component_panels[1]
         assert second_panel.id == 185
-        assert second_panel.name == \
-            "Limb girdle muscular dystrophies, myofibrillar myopathies and distal myopathies"
+        assert (
+            second_panel.name
+            == "Limb girdle muscular dystrophies, myofibrillar myopathies and distal myopathies"
+        )
         assert second_panel.version == "4.22"
         assert second_panel.panel_source == "PanelApp"
 
         second_panel_genes = second_panel.genes
         assert len(second_panel_genes) == 1
         assert second_panel_genes[0]["gene_data"]["hgnc_id"] == "HGNC:3756"
-        assert second_panel_genes[0]["gene_data"]["gene_name"] == \
-            "filamin C"
-
+        assert second_panel_genes[0]["gene_data"]["gene_name"] == "filamin C"
 
     def test_region_occurs_in_more_than_one_panel(self):
         """
         A situation where a region appears in TWO subpanels
-        EXPECT: region to be attributed to both panels, with info such as MOI 
+        EXPECT: region to be attributed to both panels, with info such as MOI
         separated out correctly
         NOTE that the example regions file here was made by duplicating a region
          from 'superpanel_api_example_one_gene_two_panels.json; and then
-        changing the panel in the JSON, while the other files were just made 
+        changing the panel in the JSON, while the other files were just made
         by deleting sections of 'real' API calls
         """
         json_response = mocked_requests_get_superpanel(
             "testing_files/panelapp_api_mocks/superpanel_api_example_one_region_two_panels.json"
         )
         superpanel = SuperPanelClass(**json_response)
-        component_panels = superpanel.create_component_panels(superpanel.genes,
-                                                              superpanel.regions)
-        
+        component_panels = superpanel.create_component_panels(
+            superpanel.genes, superpanel.regions
+        )
+
         assert len(component_panels) == 2
 
         first_panel = component_panels[0]
@@ -231,12 +244,10 @@ class TestSuperPanelClass(TestCase):
 
         second_panel = component_panels[1]
         assert second_panel.id == 100
-        assert second_panel.name == \
-            "Other motor neuronopathies"
+        assert second_panel.name == "Other motor neuronopathies"
         assert second_panel.version == "3.6"
         assert second_panel.panel_source == "PanelApp"
 
         second_panel_regions = second_panel.regions
         assert len(second_panel_regions) == 1
         assert second_panel_regions[0]["entity_name"] == "ISCA-37404-Loss"
-    

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_gene_and_transcript_to_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_gene_and_transcript_to_db.py
@@ -1,28 +1,29 @@
 from django.test import TestCase
 
 
-from requests_app.models import \
-    Gene, Transcript
+from requests_app.models import Gene, Transcript
 
 
-from requests_app.management.commands._parse_transcript import \
-    _add_gene_and_transcript_to_db
+from requests_app.management.commands._parse_transcript import (
+    _add_gene_and_transcript_to_db,
+)
 from ..test_insert_panel.test_insert_gene import len_check_wrapper, value_check_wrapper
 
 
 class TestAddGeneTranscript_FromScratch(TestCase):
     """
-    Cases where transcripts and genes are being added to a 'clean' 
-    database with no entries - emulates situations where the gene 
-    and transcript aren't already in the database, have old 
+    Cases where transcripts and genes are being added to a 'clean'
+    database with no entries - emulates situations where the gene
+    and transcript aren't already in the database, have old
     versions that need handling, and so on.
 
     One case is for when a gene has 1 transcript,
     another is for multiple transcripts.
     """
+
     def setUp(self) -> None:
         return super().setUp()
-    
+
     def test_add_new_gene_new_transcript_single(self):
         """
         Straightforward use case, one transcript per gene
@@ -45,13 +46,14 @@ class TestAddGeneTranscript_FromScratch(TestCase):
         err += value_check_wrapper(new_genes[0].gene_symbol, "gene symbol", None)
 
         err += len_check_wrapper(new_transcripts, "transcript", 1)
-        err += value_check_wrapper(new_transcripts[0].transcript, "transcript name", "NM00045.6")
+        err += value_check_wrapper(
+            new_transcripts[0].transcript, "transcript name", "NM00045.6"
+        )
         err += value_check_wrapper(new_transcripts[0].source, "source", "MANE")
         err += value_check_wrapper(new_transcripts[0].reference_genome, "ref", "")
 
         errors = "; ".join(err)
         assert not errors, errors
-
 
     def test_add_new_gene_new_transcript_multiple(self):
         """
@@ -65,7 +67,6 @@ class TestAddGeneTranscript_FromScratch(TestCase):
         source = None
 
         _add_gene_and_transcript_to_db(hgnc_id, transcripts, reference, source)
-
 
         new_genes = Gene.objects.all()
         new_transcripts = Transcript.objects.all()
@@ -94,7 +95,7 @@ class TestAddGeneTranscript_AlreadyExists(TestCase):
     Cases where transcripts are being added to a database which
     already contains a gene and transcript.
 
-    Testing transcripts are still created if they are different in e.g. their reference version 
+    Testing transcripts are still created if they are different in e.g. their reference version
     or source, from an already-existing transcript.
 
     #TODO: needs development - as part of plans to implement a more informative
@@ -102,17 +103,14 @@ class TestAddGeneTranscript_AlreadyExists(TestCase):
     """
 
     def setUp(self) -> None:
-        self.start_gene = Gene.objects.create(
-            hgnc_id="HGNC:0001"
-        )
+        self.start_gene = Gene.objects.create(hgnc_id="HGNC:0001")
 
         self.start_transcript = Transcript.objects.get_or_create(
             transcript="NM00045.6",
             source="MANE",
             gene_id=self.start_gene.pk,
-            reference_genome="37"
+            reference_genome="37",
         )
-    
 
     def test_add_old_gene_changed_transcript(self):
         err = []

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_clin_transcript_from_hgmd_files.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_clin_transcript_from_hgmd_files.py
@@ -3,8 +3,9 @@ from django.test import TestCase
 import numpy as np
 
 
-from requests_app.management.commands._parse_transcript import \
-    _get_clin_transcript_from_hgmd_files
+from requests_app.management.commands._parse_transcript import (
+    _get_clin_transcript_from_hgmd_files,
+)
 
 
 class TestHgmdFileFetcher_ErrorStates(TestCase):
@@ -13,8 +14,9 @@ class TestHgmdFileFetcher_ErrorStates(TestCase):
         markname = {"not_1234": ["5678"]}
         gene2refseq = {}
 
-        result, test_error = _get_clin_transcript_from_hgmd_files(hgnc_id, markname, 
-                                                                  gene2refseq)
+        result, test_error = _get_clin_transcript_from_hgmd_files(
+            hgnc_id, markname, gene2refseq
+        )
 
         expected_err = "HGNC:1234 not found in markname HGMD table"
 
@@ -25,20 +27,22 @@ class TestHgmdFileFetcher_ErrorStates(TestCase):
         markname = {"1234": ["5678", "9101"]}
         gene2refseq = {}
 
-        result, test_error = _get_clin_transcript_from_hgmd_files(hgnc_id, markname, 
-                                                                  gene2refseq)
+        result, test_error = _get_clin_transcript_from_hgmd_files(
+            hgnc_id, markname, gene2refseq
+        )
 
         expected_err = "HGNC:1234 has two or more entries in markname HGMD table."
 
         assert test_error == expected_err
-        
+
     def test_markname_gene_id_blank_string(self):
         hgnc_id = "HGNC:1234"
         markname = {"1234": [""]}
         gene2refseq = {}
 
-        result, test_error = _get_clin_transcript_from_hgmd_files(hgnc_id, markname, 
-                                                                  gene2refseq)
+        result, test_error = _get_clin_transcript_from_hgmd_files(
+            hgnc_id, markname, gene2refseq
+        )
 
         expected_err = "HGNC:1234 has no gene_id in markname table"
 
@@ -49,8 +53,9 @@ class TestHgmdFileFetcher_ErrorStates(TestCase):
         markname = {"1234": [None]}
         gene2refseq = {}
 
-        result, test_error = _get_clin_transcript_from_hgmd_files(hgnc_id, markname, 
-                                                                  gene2refseq)
+        result, test_error = _get_clin_transcript_from_hgmd_files(
+            hgnc_id, markname, gene2refseq
+        )
 
         expected_err = "HGNC:1234 has no gene_id in markname table"
 
@@ -61,8 +66,9 @@ class TestHgmdFileFetcher_ErrorStates(TestCase):
         markname = {"1234": [np.nan]}
         gene2refseq = {}
 
-        result, test_error = _get_clin_transcript_from_hgmd_files(hgnc_id, markname, 
-                                                                  gene2refseq)
+        result, test_error = _get_clin_transcript_from_hgmd_files(
+            hgnc_id, markname, gene2refseq
+        )
 
         expected_err = "HGNC:1234 has no gene_id in markname table"
 
@@ -73,24 +79,28 @@ class TestHgmdFileFetcher_ErrorStates(TestCase):
         markname = {"1234": ["5678"]}
         gene2refseq = {}
 
-        result, test_error = _get_clin_transcript_from_hgmd_files(hgnc_id, markname, 
-                                                                  gene2refseq)
+        result, test_error = _get_clin_transcript_from_hgmd_files(
+            hgnc_id, markname, gene2refseq
+        )
 
         expected_err = "HGNC:1234 with gene id 5678 not in gene2refseq table"
 
         assert test_error == expected_err
-    
+
     def test_gene2reqseq_entry_contains_list_of_lists(self):
         hgnc_id = "HGNC:1234"
         markname = {"1234": ["5678"]}
         gene2refseq = {"5678": [["NM005", "1"], ["NM009", "1"]]}
 
-        result, test_error = _get_clin_transcript_from_hgmd_files(hgnc_id, markname, 
-                                                                  gene2refseq)
+        result, test_error = _get_clin_transcript_from_hgmd_files(
+            hgnc_id, markname, gene2refseq
+        )
 
-        expected_err = \
+        expected_err = (
             "HGNC:1234 has more than one transcript in the HGMD database: NM005,NM009"
+        )
 
         assert test_error == expected_err
+
 
 # For passing states, see the tests for the parent function, _transcript_assigner

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_sanity_check_cols_exist.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_sanity_check_cols_exist.py
@@ -2,8 +2,7 @@ from django.test import TestCase
 
 import pandas as pd
 
-from requests_app.management.commands._parse_transcript import \
-    _sanity_check_cols_exist
+from requests_app.management.commands._parse_transcript import _sanity_check_cols_exist
 
 
 class TestSanityCheckColsExist(TestCase):
@@ -12,6 +11,7 @@ class TestSanityCheckColsExist(TestCase):
     used for several input files.
     We mostly use the MANE file set-up here.
     """
+
     hgnc_cols = ["HGNC ID", "Approved symbol", "Alias symbols"]
     hgnc_name = "HGNC dump"
     mane_cols = ["Gene", "MANE TYPE", "RefSeq StableID GRCh38 / GRCh37"]
@@ -21,40 +21,41 @@ class TestSanityCheckColsExist(TestCase):
 
     def test_passing_case(self):
         test_mane = pd.DataFrame(
-             {"Gene": [], "MANE TYPE": [], "RefSeq StableID GRCh38 / GRCh37": []}
-             )
+            {"Gene": [], "MANE TYPE": [], "RefSeq StableID GRCh38 / GRCh37": []}
+        )
         assert not _sanity_check_cols_exist(test_mane, self.mane_cols, self.mane_name)
 
     def test_mane_missing_gene(self):
         test_mane = pd.DataFrame(
-             {"MANE TYPE": [], "RefSeq StableID GRCh38 / GRCh37": []}
-             )
-        with self.assertRaisesRegex(AssertionError, 
-                                    "Missing column Gene from MANE file - please check the file"): 
+            {"MANE TYPE": [], "RefSeq StableID GRCh38 / GRCh37": []}
+        )
+        with self.assertRaisesRegex(
+            AssertionError, "Missing column Gene from MANE file - please check the file"
+        ):
             _sanity_check_cols_exist(test_mane, self.mane_cols, self.mane_name)
 
     def test_mane_missing_mane_type(self):
-        test_mane = pd.DataFrame(
-             {"Gene": [], "RefSeq StableID GRCh38 / GRCh37": []}
-             )
-        with self.assertRaisesRegex(AssertionError, 
-                                    "Missing column MANE TYPE from MANE file - please check the file"): 
+        test_mane = pd.DataFrame({"Gene": [], "RefSeq StableID GRCh38 / GRCh37": []})
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Missing column MANE TYPE from MANE file - please check the file",
+        ):
             _sanity_check_cols_exist(test_mane, self.mane_cols, self.mane_name)
-    
+
     def test_mane_missing_refseq(self):
-        test_mane = pd.DataFrame(
-            {"Gene": [], "MANE TYPE": []}
-            )
-        with self.assertRaisesRegex(AssertionError, 
-                                    "Missing column RefSeq StableID GRCh38 / GRCh37 from MANE file - please check the file"): 
+        test_mane = pd.DataFrame({"Gene": [], "MANE TYPE": []})
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Missing column RefSeq StableID GRCh38 / GRCh37 from MANE file - please check the file",
+        ):
             _sanity_check_cols_exist(test_mane, self.mane_cols, self.mane_name)
 
     def test_mane_missing_several(self):
-        test_mane = pd.DataFrame(
-            {"Gene": []}
-            )
-        with self.assertRaisesRegex(AssertionError, 
-                                    "Missing column MANE TYPE from MANE file - please check the file; " + 
-                                    "Missing column RefSeq StableID GRCh38 / GRCh37 from MANE file - " +
-                                    "please check the file"): 
+        test_mane = pd.DataFrame({"Gene": []})
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Missing column MANE TYPE from MANE file - please check the file; "
+            + "Missing column RefSeq StableID GRCh38 / GRCh37 from MANE file - "
+            + "please check the file",
+        ):
             _sanity_check_cols_exist(test_mane, self.mane_cols, self.mane_name)

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_transcript_assigner.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_transcript_assigner.py
@@ -3,8 +3,7 @@ from django.test import TestCase
 import pandas as pd
 
 
-from requests_app.management.commands._parse_transcript import \
-    _transcript_assigner
+from requests_app.management.commands._parse_transcript import _transcript_assigner
 
 
 class TestTranscriptAssigner_AlreadyAdded(TestCase):
@@ -12,8 +11,8 @@ class TestTranscriptAssigner_AlreadyAdded(TestCase):
     CASE: gene and transcript are in gene_clinical_transcript already
     EXPECT the transcript to return as non-clinical
     """
-    def test_default_additional_transcript_non_clin(self):
 
+    def test_default_additional_transcript_non_clin(self):
         hgnc_id = "1234"
         tx = "NM00004.1"
         gene_clinical_transcript = {"1234": ["NM00008.1", "MANE"]}
@@ -22,11 +21,15 @@ class TestTranscriptAssigner_AlreadyAdded(TestCase):
         markname_hgmd = {}
         gene2refseq_hgmd = {}
 
-        clinical, source, err = _transcript_assigner(tx, hgnc_id, 
-                                                     gene_clinical_transcript, 
-                                                     mane_data, markname_hgmd, 
-                                                     gene2refseq_hgmd)
-        
+        clinical, source, err = _transcript_assigner(
+            tx,
+            hgnc_id,
+            gene_clinical_transcript,
+            mane_data,
+            markname_hgmd,
+            gene2refseq_hgmd,
+        )
+
         errors = [x for x in [clinical, source, err] if x]
 
         assert not errors, errors
@@ -36,6 +39,7 @@ class TestTranscriptAssigner_InMane(TestCase):
     """
     # CASE gene and/or transcript in MANE data
     """
+
     def test_gene_transcript_in_mane(self):
         # EXPECT the transcript to return straight away as clinical, source = MANE,
         # regardless of whether it's in other files or not
@@ -47,12 +51,14 @@ class TestTranscriptAssigner_InMane(TestCase):
         markname_hgmd = {}
         gene2refseq_hgmd = {}
 
-        clinical, source, err = _transcript_assigner(tx,
-                                                     hgnc_id,
-                                                     gene_clinical_transcript,
-                                                     mane_data,
-                                                     markname_hgmd,
-                                                     gene2refseq_hgmd)
+        clinical, source, err = _transcript_assigner(
+            tx,
+            hgnc_id,
+            gene_clinical_transcript,
+            mane_data,
+            markname_hgmd,
+            gene2refseq_hgmd,
+        )
 
         errors = [x for x in [clinical, source == "MANE", not err] if not x]
 
@@ -63,6 +69,7 @@ class TestTranscriptAssigner_GeneInHgmd(TestCase):
     """
     CASE testing presence/absence in HGMD
     """
+
     def test_gene_transcript_in_hgmd(self):
         # Transcript in HGMD matches the transcript we're currently feeding to the function
         # Expect it to be tagged clinical with 'HGMD' as source
@@ -74,12 +81,14 @@ class TestTranscriptAssigner_GeneInHgmd(TestCase):
         markname_hgmd = {"1234": ["test"]}
         gene2refseq_hgmd = {"test": [["NM00004", "1"]]}
 
-        clinical, source, err = _transcript_assigner(tx,
-                                                     hgnc_id,
-                                                     gene_clinical_transcript,
-                                                     mane_data,
-                                                     markname_hgmd,
-                                                     gene2refseq_hgmd)
+        clinical, source, err = _transcript_assigner(
+            tx,
+            hgnc_id,
+            gene_clinical_transcript,
+            mane_data,
+            markname_hgmd,
+            gene2refseq_hgmd,
+        )
 
         errors = [x for x in [clinical, source == "HGMD", not err] if not x]
 
@@ -96,12 +105,14 @@ class TestTranscriptAssigner_GeneInHgmd(TestCase):
         markname_hgmd = {"1234": ["1"]}
         gene2refseq_hgmd = {"1": [["NM00004", "2"]]}
 
-        clinical, source, err = _transcript_assigner(tx,
-                                                     hgnc_id,
-                                                     gene_clinical_transcript,
-                                                     mane_data,
-                                                     markname_hgmd,
-                                                     gene2refseq_hgmd)
+        clinical, source, err = _transcript_assigner(
+            tx,
+            hgnc_id,
+            gene_clinical_transcript,
+            mane_data,
+            markname_hgmd,
+            gene2refseq_hgmd,
+        )
 
         errors = [x for x in [clinical, source, err] if x]
 

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
@@ -3,38 +3,32 @@ import numpy as np
 
 from requests_app.models import Gene
 
-from requests_app.management.commands._parse_transcript import \
-    _update_existing_gene_metadata_in_db
+from requests_app.management.commands._parse_transcript import (
+    _update_existing_gene_metadata_in_db,
+)
 
 
 class TestUpdateExistingGene(TestCase):
     """
     Test various cases on _update_existing_gene_metadata_in_db
     """
+
     def setUp(self) -> None:
         # Populate the Gene test database with some easy examples
         self.FAM234A = Gene.objects.create(
             hgnc_id="14163",
             gene_symbol="FAM234A",
-            alias_symbols="DKFZP761D0211,FLJ32603"
+            alias_symbols="DKFZP761D0211,FLJ32603",
         )
 
         Gene.objects.create(
-            hgnc_id="12713",
-            gene_symbol="VPS41",
-            alias_symbols="HVSP41"
+            hgnc_id="12713", gene_symbol="VPS41", alias_symbols="HVSP41"
         )
 
-        Gene.objects.create(
-            hgnc_id="50000",
-            gene_symbol="YFP1",
-            alias_symbols="ABC"
-        )
+        Gene.objects.create(hgnc_id="50000", gene_symbol="YFP1", alias_symbols="ABC")
 
         Gene.objects.create(
-            hgnc_id="51000",
-            gene_symbol="YFP2",
-            alias_symbols="ABCD,EFGH"
+            hgnc_id="51000", gene_symbol="YFP2", alias_symbols="ABCD,EFGH"
         )
 
     def test_no_changes(self):
@@ -42,7 +36,7 @@ class TestUpdateExistingGene(TestCase):
         A gene is unchanged
         """
         test_hgnc_approved = {"14163": "FAM234A"}
-        test_aliases = {"14163": ["DKFZP761D0211", "FLJ32603"]}        
+        test_aliases = {"14163": ["DKFZP761D0211", "FLJ32603"]}
         _update_existing_gene_metadata_in_db(test_hgnc_approved, test_aliases)
 
         # check that the entry isn't changed from how it was at set-up
@@ -58,7 +52,7 @@ class TestUpdateExistingGene(TestCase):
         Aliases aren't changed here
         """
         made_up_approved_name = "FAM234A_test"
-        test_hgnc_approved = {"14163": made_up_approved_name} 
+        test_hgnc_approved = {"14163": made_up_approved_name}
         test_hgnc_aliases = {"14163": ["DKFZP761D0211", "FLJ32603"]}
         _update_existing_gene_metadata_in_db(test_hgnc_approved, test_hgnc_aliases)
 
@@ -76,10 +70,14 @@ class TestUpdateExistingGene(TestCase):
         made_up_approved_name = "FAM234A_test"
         made_up_approved_name_two = "test_nonsense"
 
-        test_hgnc_approved = {"14163": made_up_approved_name, 
-                              "12713": made_up_approved_name_two}
-        test_hgnc_aliases = {"14163": ["DKFZP761D0211", "FLJ32603"],
-                             "12713": ["HVSP41"]}
+        test_hgnc_approved = {
+            "14163": made_up_approved_name,
+            "12713": made_up_approved_name_two,
+        }
+        test_hgnc_aliases = {
+            "14163": ["DKFZP761D0211", "FLJ32603"],
+            "12713": ["HVSP41"],
+        }
         _update_existing_gene_metadata_in_db(test_hgnc_approved, test_hgnc_aliases)
 
         # check that the entry for 14163 in the Gene test datatable is updated
@@ -96,7 +94,7 @@ class TestUpdateExistingGene(TestCase):
         Test case: the alias name has changed for a gene, since last update
         No change in approved name
         """
-        test_hgnc_approved = {"14163": "FAM234A"} 
+        test_hgnc_approved = {"14163": "FAM234A"}
         made_up_aliases = ["alias1", "alias2"]
         test_hgnc_aliases = {"14163": made_up_aliases}
 
@@ -123,7 +121,7 @@ class TestUpdateExistingGene(TestCase):
         gene_db = Gene.objects.filter(hgnc_id="14163")
         assert len(gene_db) == 1
         assert gene_db[0].alias_symbols == self.FAM234A.alias_symbols
-    
+
     def test_alias_list_empty(self):
         """
         Test case: the alias name has changed for a gene, since last update

--- a/web/admin.py
+++ b/web/admin.py
@@ -1,2 +1,1 @@
-
 # Register your models here.

--- a/web/models.py
+++ b/web/models.py
@@ -1,2 +1,1 @@
-
 # Create your models here.

--- a/web/tests.py
+++ b/web/tests.py
@@ -1,2 +1,1 @@
-
 # Create your tests here.

--- a/web/views.py
+++ b/web/views.py
@@ -1452,9 +1452,9 @@ def genepanel(request):
         ci_panels[row["clinical_indication_id__r_code"]].append(row)
 
     # fetch all relevant genes for the relevant panels
-    for row in PanelGene.objects.filter(panel_id__in=relevant_panels, active=True).values(
-        "gene_id__hgnc_id", "gene_id", "panel_id"
-    ):
+    for row in PanelGene.objects.filter(
+        panel_id__in=relevant_panels, active=True
+    ).values("gene_id__hgnc_id", "gene_id", "panel_id"):
         panel_genes[row["panel_id"]].append((row["gene_id__hgnc_id"], row["gene_id"]))
 
     list_of_genepanel: list[Genepanel] = []


### PR DESCRIPTION
Problem: A small number of panels in PanelApp are super-panels, which are made by collecting a set of standard panels together. An example is panel ID 465, 'Other rare neuromuscular disorders'. The result was Eris was treating super-panels erratically. 
For example, they can contain the same gene more than once, which isn't the case for standard panels, and that can cause a gene to have the incorrect confidence assigned to it within a superpanel. Therefore, changes needed to be made to ensure super-panels are processed correctly.

Changes: Superpanels are now parsed from the JSON with SuperPanelClass, which creates a list of child PanelClass objects to represent the constituent panels. Rather than being stored in the Panel table, superpanels are stored in the SuperPanel database table, and a linking table connects them to their child Panels. Code that handles panels and clinical indication assignment has been changed to extract from the new SuperPanels in addition to the old Panels.

Current state: Unit tests are passing, and '_generate_genepanels' works correctly to output. The original issue no longer occurs, because instead of being linked to SuperPanels directly, Genes are linked to the child Panels instead.

**Unit test passing as of 23rd Oct 2023, 09:14:**

```
(eris_3.10) corbin@starling:~/wc/eris/eris$ python manage.py test
Found 81 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
Inserting test directory data into database... forced: False
R123: No SuperPanel record has panelapp ID 123
Data insertion completed.
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
R234: No SuperPanel record has panelapp ID 123
R234: No SuperPanel record has panelapp ID 234
Data insertion completed.
.Inserting test directory data into database... forced: True
Data insertion completed.
.Inserting test directory data into database... forced: False
.Inserting test directory data into database... forced: False
R67.1: No SuperPanel record has panelapp ID 123
Data insertion completed.
.Inserting test directory data into database... forced: False
.Inserting test directory data into database... forced: False
.Inserting test directory data into database... forced: False
R123: No SuperPanel record has panelapp ID 123
Data insertion completed.
.Inserting test directory data into database... forced: False
R123: No SuperPanel record has panelapp ID 234
Data insertion completed.
.Inserting test directory data into database... forced: False
R123: No SuperPanel record has panelapp ID 123
Data insertion completed.
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
..............None: No Panel record has panelapp ID 999
...........For panel Acute rhabdomyolyosis, skipping gene without HGNC ID: acyl-CoA dehydrogenase family member 9
............................................
----------------------------------------------------------------------
Ran 81 tests in 2.593s

OK
Destroying test database for alias 'default'...

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/43)
<!-- Reviewable:end -->
