### PR TITLE
In 334 335 release info

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ MANE and HGMD files should be version-controlled locally, with file IDs for ever
 
 ```
 python manage.py seed transcript \
---hgnc <path> --mane <path> --mane_ext_id <file ID> --mane_release <release> \
+--hgnc <path> --hgnc_release <release> --mane <path> --mane_ext_id <file ID> --mane_release <release> \
 --gff <path> --g2refseq <path> --g2refseq_ext_id <file ID> --markname <path> \
 --markname_ext_id <file ID> --hgmd_release_label <str> --refgenome <version> \
 --error
@@ -81,15 +81,17 @@ python manage.py seed transcript \
 
 The arguments are as follows:
 - `hgnc`: path to HGMC dump txt file, allowing gene names to be standardised. The file is CSV format and contains columns for HGNC ID, Approved Symbol, Previous Symbols, Alias Symbols. This file should be documented with a release version. An example HGNC file can be downloaded from: https://www.genenames.org/download/custom/
+- `hgnc_release`: the documented release version for the `hgnc` file.
 - `mane`: path to MANE CSV file, which informs which transcripts are labelled as clinical. This file should be documented with a release version. An example GRCh37 file is available at: http://tark.ensembl.org/web/mane_GRCh37_list/
 - `mane_ext_id`: the external file ID for the release-tagged MANE CSV file
 - `mane_release`: the release version associated with the MANE CSV file and its file ID.
 - `gff`: path to parsed gff.tsv (project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gk7gZ47gypK7ZZ)
+- `gff_release`: the documented release version for the `gff` file.
 - `g2refseq`: path to the g2refseq table from the HGMD database, in csv format
 - `g2refseq_ext_id`: external file ID for release-tagged HGMD g2refseq table
 - `markname`: path to markname table from the HGMD database, in csv format
 - `markname_ext_id`: external file ID for versioned HGMD markname table
-- `hgmd_release_label`: the release version of HGMD, associated with both markname and g2refseq
+- `hgmd_release`: the release version of HGMD, associated with both markname and g2refseq
 - `refgenome`: reference genome. Permitted values are: 37/GRCh37/hg19 or 38/GRCh38/hg38
 
 *HGMD database source can be found on DNAnexus (project-Fz4Q15Q42Z9YjYk110b3vGYQ:file-Fz4Q46842Z9z2Q6ZBjy7jVPY)

--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ python manage.py seed transcript --hgnc testing_files/hgnc_dump_20230613.txt --m
 
 The arguments are as follows:
 - `hgnc`: path to HGMC dump txt file, allowing gene names to be standardised. The file is CSV format and contains columns for HGNC ID, Approved Symbol, Previous Symbols, Alias Symbols. This file should be documented with a release version. An example HGNC file can be downloaded from: https://www.genenames.org/download/custom/
-- `hgnc_release`: the documented release version for the `hgnc` file.
+- `hgnc_release`: the documented release version for the `hgnc` file. This must consist only of numbers and full stops, e.g. 1.0.1.
 - `mane`: path to MANE CSV file, which informs which transcripts are labelled as clinical. This file should be documented with a release version. An example GRCh37 file is available at: http://tark.ensembl.org/web/mane_GRCh37_list/
 - `mane_ext_id`: the external file ID for the release-tagged MANE CSV file
-- `mane_release`: the release version associated with the MANE CSV file and its file ID.
+- `mane_release`: the release version associated with the MANE CSV file and its file ID. This must consist only of numbers and full stops, e.g. 1.0.1.
 - `gff`: path to parsed gff.tsv (project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gk7gZ47gypK7ZZ)
-- `gff_release`: the documented release version for the `gff` file.
+- `gff_release`: the documented release version for the `gff` file. This must consist only of numbers and full stops, e.g. 1.0.1.
 - `g2refseq`: path to the g2refseq table from the HGMD database, in csv format
 - `g2refseq_ext_id`: external file ID for release-tagged HGMD g2refseq table
 - `markname`: path to markname table from the HGMD database, in csv format
 - `markname_ext_id`: external file ID for versioned HGMD markname table
-- `hgmd_release`: the release version of HGMD, associated with both markname and g2refseq
+- `hgmd_release`: the release version of HGMD, associated with both markname and g2refseq. This must consist only of numbers and full stops, e.g. 1.0.1.
 - `refgenome`: reference genome. Permitted values are: 37/GRCh37/hg19 or 38/GRCh38/hg38
 
 *HGMD database source can be found on DNAnexus (project-Fz4Q15Q42Z9YjYk110b3vGYQ:file-Fz4Q46842Z9z2Q6ZBjy7jVPY)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python manage.py seed transcript \
 --error
 
 # working example
-python manage.py seed transcript --hgnc testing_files/hgnc_dump_20230613.txt --mane testing_files/mane_grch37.csv --mane_ext_id file-123 --mane_release 1.0 --gff testing_files/GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv --g2refseq testing_files/gene2refseq_202306131409.csv --g2refseq_ext_id file-123 --markname testing_files/markname_202306131409.csv --markname_ext_id file-234 --hgmd_release_label 1.4 --refgenome grch37
+python manage.py seed transcript --hgnc testing_files/hgnc_dump_20230613.txt --hgnc_release 1.0 --mane testing_files/mane_grch37.csv --mane_ext_id file-123 --mane_release 1.0 --gff testing_files/GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv --gff_release 1.0 --g2refseq testing_files/gene2refseq_202306131409.csv --g2refseq_ext_id file-123 --markname testing_files/markname_202306131409.csv --markname_ext_id file-234 --hgmd_release 1.4 --refgenome grch37
 ```
 
 The arguments are as follows:

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -33,7 +33,7 @@ def _update_existing_gene_metadata_symbol_in_db(
     user: str
 ) -> None:
     """
-    Function to update gene metadata in db using hgnc dump prepared dictionaries
+    Function to update gene metadata in db using a hgnc dump prepared dictionary
     Updates approved symbol if that has changed.
     To speed up the function, we utilise looping over lists-of-dictionaries,
     and bulk updates in some spots.
@@ -63,7 +63,7 @@ def _update_existing_gene_metadata_symbol_in_db(
             hgnc_release=hgnc_release
         )
 
-        GeneHgncReleaseHistory(gene_hgnc_release=gene_hgnc_release,
+        GeneHgncReleaseHistory.objects.create(gene_hgnc_release=gene_hgnc_release,
                            note=History.gene_hgnc_release_approved_symbol_change(),
                            user=user)
 

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -197,8 +197,8 @@ def _make_hgnc_gene_sets(
     :return hgnc_unchanged: a list of HGNC IDs for genes which are in the release, but unchanged
     """
     # get every HGNC ID in the HGNC file
-    all_hgnc_in_approved = hgnc_id_to_symbol.keys()
-    all_hgnc_in_alias = hgnc_id_to_alias.keys()
+    all_hgnc_in_approved = list(hgnc_id_to_symbol.keys())
+    all_hgnc_in_alias = list(hgnc_id_to_alias.keys())
     all_hgnc_file_entries = all_hgnc_in_alias + all_hgnc_in_approved
 
     # for hgnc_ids which already exist in the database, get the ones which have changed

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -82,7 +82,7 @@ def _update_existing_gene_metadata_aliases_in_db(
     """
     gene_alias_updates = []
 
-    for changed_gene, new_alias in hgnc_id_to_alias_symbols:
+    for changed_gene, new_alias in hgnc_id_to_alias_symbols.items():
         gene = Gene.objects.get(hgnc_id=changed_gene)
         gene.alias_symbols = new_alias
         gene_alias_updates.append(gene)

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -119,15 +119,18 @@ def _link_unchanged_genes_to_new_release(unchanged_genes: list, hgnc_release: Hg
     for hgnc_id in unchanged_genes:
         gene = Gene.objects.get(hgnc_id=hgnc_id)
 
-        gene_hgnc_release = GeneHgncRelease.objects.create(
+        gene_hgnc_release, release_created = GeneHgncRelease.objects.get_or_create(
             gene=gene,
             hgnc_release=hgnc_release
         )
 
-        GeneHgncReleaseHistory.objects.create(
-            gene_hgnc_release=gene_hgnc_release,
-                           note=History.gene_hgnc_release_present(),
-                           user=user)
+        # if a new gene-release link was made, log it in history
+        # if it existed already, don't log it
+        if release_created:
+            GeneHgncReleaseHistory.objects.create(
+                gene_hgnc_release=gene_hgnc_release,
+                            note=History.gene_hgnc_release_present(),
+                            user=user)
 
 
 def _add_new_genes_to_db(

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -125,7 +125,7 @@ def _link_unchanged_genes_to_new_release(unchanged_genes: list, hgnc_release: Hg
                            note=History.gene_hgnc_release_unchanged,
                            user=user)
 
-# TODO: what if a HGNC_ID is retired?
+
 def _add_new_genes_to_db(
     new_genes: dict[str:str], hgnc_release: HgncRelease, user: str
 ) -> None:

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -246,7 +246,8 @@ def _make_hgnc_gene_sets(
             ),
             "alias": (
                 ",".join(hgnc_id_to_alias[hgnc_id])
-                if hgnc_id_to_alias[hgnc_id]
+                if (hgnc_id_to_alias[hgnc_id]
+                and not pd.isna(hgnc_id_to_alias[hgnc_id]).all)
                 else None
             ),
         }
@@ -287,7 +288,7 @@ def _prepare_hgnc_file(hgnc_file: str, hgnc_version: str, user: str) -> dict[str
     )
 
     # create a HGNC release
-    hgnc_release, _ = HgncRelease.objects.create(hgnc_release=hgnc_version)
+    hgnc_release = HgncRelease.objects.create(hgnc_release=hgnc_version)
 
     # get all possible HGNC IDs from the HGNC file, and compare to what's already in the database,
     # to sort them into those which need adding and those which need editing

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -820,12 +820,11 @@ def _parse_reference_genome(ref_genome: str) -> str:
             f" such as {'; '.join(permitted_grch37)} or "
             f"{'; '.join(permitted_grch38)} - you provided {ref_genome}"
         )
-    
 
-def _check_for_transcript_seeding_version_regression(hgnc_release: str,
-                                  gff_release: str,
-                                  mane_release: str,
-                                  hgmd_release: str) -> None:
+
+def _check_for_transcript_seeding_version_regression(
+    hgnc_release: str, gff_release: str, mane_release: str, hgmd_release: str
+) -> None:
     """
     For any releases needed for transcript seeding,
     get the latest ones in the database, and check that the user hasn't entered an older one.
@@ -842,11 +841,28 @@ def _check_for_transcript_seeding_version_regression(hgnc_release: str,
     latest_gff = GffRelease.objects.all().order_by("-gff_release").first()
 
     # for MANE need to check both Select and Plus Clinical to find the max
-    latest_select = TranscriptRelease.objects.filter(source__source="MANE Select").order_by("-external_release_version").first()
-    latest_plus_clinical = TranscriptRelease.objects.filter(source__source="MANE Plus Clinical").order_by("-external_release_version").first()
-    latest_mane = max([latest_select.external_release_version, latest_plus_clinical.external_release_version])
+    latest_select = (
+        TranscriptRelease.objects.filter(source__source="MANE Select")
+        .order_by("-external_release_version")
+        .first()
+    )
+    latest_plus_clinical = (
+        TranscriptRelease.objects.filter(source__source="MANE Plus Clinical")
+        .order_by("-external_release_version")
+        .first()
+    )
+    latest_mane = max(
+        [
+            latest_select.external_release_version,
+            latest_plus_clinical.external_release_version,
+        ]
+    )
 
-    latest_hgmd = TranscriptRelease.objects.filter(source__source="HGMD").order_by("-external_release_version").first()
+    latest_hgmd = (
+        TranscriptRelease.objects.filter(source__source="HGMD")
+        .order_by("-external_release_version")
+        .first()
+    )
 
     too_old = {}
 
@@ -871,7 +887,7 @@ def _check_for_transcript_seeding_version_regression(hgnc_release: str,
             joined_output_str.append(f"{key} is a lower version than {value}")
         error = "; ".join(joined_output_str)
         raise Exception("Abandoning input because: " + error)
-        
+
 
 # 'atomic' should ensure that any failure rolls back the entire attempt to seed
 # transcripts - resetting the database to its start position
@@ -927,7 +943,9 @@ def seed_transcripts(
     )
 
     # throw errors if the release versions are older than those already in the db
-    _check_for_transcript_seeding_version_regression(hgnc_release, gff_release, mane_release, hgmd_release)
+    _check_for_transcript_seeding_version_regression(
+        hgnc_release, gff_release, mane_release, hgmd_release
+    )
 
     # user - replace this with something sensible one day
     user = "transcripts_test_user"

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -93,7 +93,7 @@ def _update_existing_gene_metadata_aliases_in_db(
 
     # for each changed gene, link to release and add a note
     for gene in gene_alias_updates:
-        gene_hgnc_release = GeneHgncRelease.objects.create(
+        gene_hgnc_release, _ = GeneHgncRelease.objects.get_or_create(
             gene=gene, hgnc_release=hgnc_release
         )
 
@@ -234,8 +234,6 @@ def _make_hgnc_gene_sets(
 
     # get HGNC IDs which are in the HGNC file, but not yet in db
     new_hgncs = list(set(all_hgnc_file_entries) - set([i.hgnc_id for i in genes_in_db]))
-    for i in new_hgncs:
-        print(hgnc_id_to_alias[i])
     new_hgncs = [
         {
             "hgnc_id": hgnc_id,

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -184,7 +184,7 @@ def _add_new_genes_to_db(
 
 def _make_hgnc_gene_sets(
     hgnc_id_to_symbol: dict[str:str], hgnc_id_to_alias: dict[str:str]
-    ) -> tuple[list, dict, dict, list]:
+) -> tuple[list, dict, dict, list]:
     """
     Sort genes into:
     - those which are not yet in the Gene table, but are in the HGNC release
@@ -228,7 +228,9 @@ def _make_hgnc_gene_sets(
                 hgnc_symbol_changed[gene.hgnc_id] = {}
                 symbol_change = True
                 hgnc_symbol_changed[gene.hgnc_id]["old"] = gene.gene_symbol
-                hgnc_symbol_changed[gene.hgnc_id]["new"] = hgnc_id_to_symbol[gene.hgnc_id]
+                hgnc_symbol_changed[gene.hgnc_id]["new"] = hgnc_id_to_symbol[
+                    gene.hgnc_id
+                ]
 
         # check alias change
         if gene.hgnc_id in hgnc_id_to_alias:
@@ -241,7 +243,11 @@ def _make_hgnc_gene_sets(
                 hgnc_alias_changed[gene.hgnc_id]["new"] = resolved_alias
 
         # if the database gene is unchanged, add it to an 'unchanged' list if it's in HGNC file
-        if not symbol_change and not alias_change and gene.hgnc_id in all_hgnc_file_entries:
+        if (
+            not symbol_change
+            and not alias_change
+            and gene.hgnc_id in all_hgnc_file_entries
+        ):
             hgnc_unchanged.append(gene.hgnc_id)
 
     # get HGNC IDs which are in the HGNC file, but not yet in db
@@ -249,9 +255,7 @@ def _make_hgnc_gene_sets(
     new_hgncs = [
         {
             "hgnc_id": hgnc_id,
-            "symbol": (
-                hgnc_id_to_symbol.get(hgnc_id)
-            ),
+            "symbol": (hgnc_id_to_symbol.get(hgnc_id)),
             "alias": _resolve_alias(hgnc_id_to_alias[hgnc_id]),
         }
         for hgnc_id in new_hgncs
@@ -950,7 +954,9 @@ def _check_for_transcript_seeding_version_regression(
             too_old["gff release"] = latest_gff
 
     if too_old:
-        error = "; ".join([f"{key} is a lower version than {value}" for key, value in too_old.items()])
+        error = "; ".join(
+            [f"{key} is a lower version than {value}" for key, value in too_old.items()]
+        )
         raise ValueError("Abandoning input because: " + error)
 
 
@@ -1012,7 +1018,7 @@ def seed_transcripts(
         hgnc_release, gff_release, mane_release, hgmd_release, reference_genome
     )
 
-    #TODO: user - replace this with something sensible one day
+    # TODO: user - replace this with something sensible one day
     user = "init_v1_user"
 
     # files preparation - parsing the files, and adding release versioning to the database

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -162,7 +162,7 @@ def _add_new_genes_to_db(
             hgnc_release=hgnc_release
         )
 
-        GeneHgncReleaseHistory(gene_hgnc_release=gene_hgnc_release,
+        GeneHgncReleaseHistory.objects.create(gene_hgnc_release=gene_hgnc_release,
                            note=History.gene_hgnc_release_new(),
                            user=user)
 

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -250,7 +250,7 @@ def _make_hgnc_gene_sets(
         {
             "hgnc_id": hgnc_id,
             "symbol": (
-                hgnc_id_to_symbol[hgnc_id] if hgnc_id_to_symbol[hgnc_id] else None
+                hgnc_id_to_symbol.get(hgnc_id)
             ),
             "alias": _resolve_alias(hgnc_id_to_alias[hgnc_id]),
         }

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -218,10 +218,12 @@ def _make_hgnc_gene_sets(hgnc_id_to_symbol: dict[str: str], hgnc_id_to_alias: di
                 alias_change = True
                 hgnc_alias_changed[gene.hgnc_id] = joined_new_alias_symbols
 
-        # if the gene is unchanged, add that to a list
+        # if the database gene is unchanged, add it to an 'unchanged' list if it's in HGNC file
+        # if it ISN'T in the HGNC file, it's not in this release - ignore it
         if not symbol_change:
             if not alias_change:
-                hgnc_unchanged.append(gene.hgnc_id)
+                if gene.hgnc_id in all_hgnc_file_entries:
+                    hgnc_unchanged.append(gene.hgnc_id)
 
     # get HGNC IDs which are in the HGNC file, but not yet in db
     new_hgncs = list(set(all_hgnc_file_entries) - set([i.hgnc_id for i in genes_in_db]))

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -822,9 +822,10 @@ def _parse_reference_genome(ref_genome: str) -> str:
             f"{'; '.join(permitted_grch38)} - you provided {ref_genome}"
         )
 
+
 def _get_latest_hgnc_release() -> str | None:
     """
-    Get the latest release in HgncRelease,using LooseVersion because the version formatting 
+    Get the latest release in HgncRelease,using LooseVersion because the version formatting
     isn't 100% consistent. Return None if the table has no matching results.
     :returns: string of latest HGNC release version, or None
     """
@@ -837,17 +838,19 @@ def _get_latest_hgnc_release() -> str | None:
         latest_hgnc = str(hgnc_releases[0])
         return latest_hgnc
 
+
 def _get_latest_gff_release(ref_genome: ReferenceGenome) -> str | None:
     """
     Get the latest GFF release in GffRelease for a given reference genome,
-      using LooseVersion because the version formatting 
+      using LooseVersion because the version formatting
     isn't 100% consistent. Return None if the table has no matching results.
 
     :param reference_genome: a ReferenceGenome object corresponding to user input
     :returns: string of latest GFF result in db, or None if no matches
     """
-    gffs = GffRelease.objects.filter(reference_genome=ref_genome).\
-        order_by("-gff_release")
+    gffs = GffRelease.objects.filter(reference_genome=ref_genome).order_by(
+        "-gff_release"
+    )
     if not gffs:
         return None
     else:
@@ -856,12 +859,15 @@ def _get_latest_gff_release(ref_genome: ReferenceGenome) -> str | None:
         latest_gff = str(gff_list[0])
         return latest_gff
 
-def _get_latest_transcript_release(source: str, ref_genome: ReferenceGenome) -> str | None:
+
+def _get_latest_transcript_release(
+    source: str, ref_genome: ReferenceGenome
+) -> str | None:
     """
     Get the latest release in the TranscriptRelease table for a given source
-    and reference genome, using LooseVersion because the version formatting 
+    and reference genome, using LooseVersion because the version formatting
     isn't 100% consistent. Return None if the table has no matching results.
-    
+
     :param source: a source string such as 'HGMD', 'MANE Plus Clinical' or 'MANE Select'
     :param reference_genome: a ReferenceGenome object corresponding to user input
     :returns: string of latest transcript release or None if no database matches
@@ -879,9 +885,13 @@ def _get_latest_transcript_release(source: str, ref_genome: ReferenceGenome) -> 
         latest = str(db_results_list[0])
         return latest
 
+
 def _check_for_transcript_seeding_version_regression(
-    hgnc_release: str, gff_release: str, mane_release: str, hgmd_release: str,
-    reference_genome: ReferenceGenome
+    hgnc_release: str,
+    gff_release: str,
+    mane_release: str,
+    hgmd_release: str,
+    reference_genome: ReferenceGenome,
 ) -> None:
     """
     For any releases needed for transcript seeding,
@@ -901,7 +911,9 @@ def _check_for_transcript_seeding_version_regression(
 
     # for MANE need to check both Select and Plus Clinical to find the max
     latest_select = _get_latest_transcript_release("MANE Select", reference_genome)
-    latest_plus_clinical = _get_latest_transcript_release("MANE Plus Clinical", reference_genome)
+    latest_plus_clinical = _get_latest_transcript_release(
+        "MANE Plus Clinical", reference_genome
+    )
     if latest_plus_clinical and latest_select:
         manes = [latest_plus_clinical, latest_select]
         manes.sort(key=LooseVersion, reverse=True)

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -183,7 +183,7 @@ def _add_new_genes_to_db(
 
 
 def _make_hgnc_gene_sets(
-    hgnc_id_to_symbol: dict[str:str], hgnc_id_to_alias: dict[str:str]
+    hgnc_id_to_symbol: dict[str:str], hgnc_id_to_alias: dict[str:list]
 ) -> tuple[list, dict, dict, list]:
     """
     Sort genes into:
@@ -197,7 +197,7 @@ def _make_hgnc_gene_sets(
     These sets are then used by downstream functions to update the database
 
     :param hgnc_id_to_approved_symbol: a dictionary of HGNC_ID to the approved symbols in the new HGNC release
-    :param hgnc_id_to_alias_symbol: a dictionary of HGNC_ID to the alias symbols in the new HGNC release
+    :param hgnc_id_to_alias_symbol: a dictionary of HGNC_ID to the list of alias symbols in the new HGNC release
 
     :return new_hgncs: a list of dicts, one per new gene, with keys 'hgnc_id' 'symbol' and 'alias'
     :return hgnc_symbol_changed: a dict-of-dicts of genes with changed symbols, keys are hgnc_ids, the nested dict has 'old' and 'new 'aliases

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -1012,8 +1012,8 @@ def seed_transcripts(
         hgnc_release, gff_release, mane_release, hgmd_release, reference_genome
     )
 
-    # user - replace this with something sensible one day
-    user = "transcripts_test_user"
+    #TODO: user - replace this with something sensible one day
+    user = "init_v1_user"
 
     # files preparation - parsing the files, and adding release versioning to the database
     hgnc_symbol_to_hgnc_id = _prepare_hgnc_file(hgnc_filepath, hgnc_release, user)

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -19,7 +19,7 @@ from requests_app.models import (
     PanelGene,
     HgncRelease,
     GeneHgncRelease,
-    GeneHgncReleaseHistory
+    GeneHgncReleaseHistory,
     ReferenceGenome,
 )
 

--- a/requests_app/management/commands/_parse_transcript.py
+++ b/requests_app/management/commands/_parse_transcript.py
@@ -262,9 +262,9 @@ def _resolve_alias(start_alias: list) -> str | None:
         if not pd.isna(start_alias).all():
             processed_alias = ",".join(start_alias)
             return processed_alias
-    
+
     return None
-    
+
 
 def _prepare_hgnc_file(hgnc_file: str, hgnc_version: str, user: str) -> dict[str, str]:
     """

--- a/requests_app/management/commands/edit.py
+++ b/requests_app/management/commands/edit.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
         ), "Command not available, options are: " + ", ".join(POSSIBLE_COMMANDS)
 
         # TODO: add user later, once we've decided on how to do that
-        user = "command line"
+        user = "init_v1_user"
 
         action: str = kwargs.get("action")
 

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -74,12 +74,12 @@ class History:
     def gene_hgnc_release_new() -> str:
         return f"HGNC gene has been added for the first time"
     
-    def gene_hgnc_release_unchanged() -> str:
-        return f"HGNC gene is unchanged in this release"
+    def gene_hgnc_release_present() -> str:
+        return f"HGNC gene is present in this release"
     
     # transcript/gff releases
-    def tx_gff_release_added() -> str:
-        return f"Transcript linked to release for first time"
+    def tx_gff_release_new() -> str:
+        return f"Transcript added from a GFF release for the first time"
     
-    def tx_gff_release_unchanged() -> str:
-        return f"Transcript is unchanged in this release"
+    def tx_gff_release_present() -> str:
+        return f"Transcript is present in this release"

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -65,14 +65,10 @@ class History:
         return f"PanelGene reverted by {user}"
 
     # gene/HGNC releases
-    def gene_hgnc_release_approved_symbol_change(
-            old_value: str,
-            new_value: str) -> str:
+    def gene_hgnc_release_approved_symbol_change(old_value: str, new_value: str) -> str:
         return f"HGNC approved symbol has changed from {old_value} to {new_value}"
 
-    def gene_hgnc_release_alias_symbol_change(
-            old_value: str,
-            new_value: str) -> str:
+    def gene_hgnc_release_alias_symbol_change(old_value: str, new_value: str) -> str:
         return f"HGNC alias symbol has changed from {old_value} to {new_value}"
 
     def gene_hgnc_release_new() -> str:

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -63,3 +63,16 @@ class History:
 
     def panel_gene_reverted(user) -> str:
         return f"PanelGene reverted by {user}"
+
+    # gene/HGNC releases
+    def gene_hgnc_release_approved_symbol_change() -> str:
+        return f"HGNC approved symbol has changed"
+    
+    def gene_hgnc_release_alias_symbol_change() -> str:
+        return f"HGNC alias symbol has changed"
+    
+    def gene_hgnc_release_approved_symbol_new() -> str:
+        return f"HGNC approved symbol has been added for the first time"
+    
+    def gene_hgnc_release_alias_symbol_new() -> str:
+        return f"HGNC alias symbol has been added for the first time"

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -65,11 +65,15 @@ class History:
         return f"PanelGene reverted by {user}"
 
     # gene/HGNC releases
-    def gene_hgnc_release_approved_symbol_change() -> str:
-        return f"HGNC approved symbol has changed"
+    def gene_hgnc_release_approved_symbol_change(
+            old_value: str,
+            new_value: str) -> str:
+        return f"HGNC approved symbol has changed from {old_value} to {new_value}"
 
-    def gene_hgnc_release_alias_symbol_change() -> str:
-        return f"HGNC alias symbol has changed"
+    def gene_hgnc_release_alias_symbol_change(
+            old_value: str,
+            new_value: str) -> str:
+        return f"HGNC alias symbol has changed from {old_value} to {new_value}"
 
     def gene_hgnc_release_new() -> str:
         return f"HGNC gene has been added for the first time"

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -71,8 +71,5 @@ class History:
     def gene_hgnc_release_alias_symbol_change() -> str:
         return f"HGNC alias symbol has changed"
     
-    def gene_hgnc_release_approved_symbol_new() -> str:
-        return f"HGNC approved symbol has been added for the first time"
-    
-    def gene_hgnc_release_alias_symbol_new() -> str:
-        return f"HGNC alias symbol has been added for the first time"
+    def gene_hgnc_release_new() -> str:
+        return f"HGNC gene has been added for the first time"

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -73,3 +73,6 @@ class History:
     
     def gene_hgnc_release_new() -> str:
         return f"HGNC gene has been added for the first time"
+    
+    def gene_hgnc_release_unchanged() -> str:
+        return f"HGNC gene is unchanged in this release"

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -76,3 +76,10 @@ class History:
     
     def gene_hgnc_release_unchanged() -> str:
         return f"HGNC gene is unchanged in this release"
+    
+    # transcript/gff releases
+    def tx_gff_release_added() -> str:
+        return f"Transcript linked to release for first time"
+    
+    def tx_gff_release_unchanged() -> str:
+        return f"Transcript is unchanged in this release"

--- a/requests_app/management/commands/history.py
+++ b/requests_app/management/commands/history.py
@@ -67,19 +67,19 @@ class History:
     # gene/HGNC releases
     def gene_hgnc_release_approved_symbol_change() -> str:
         return f"HGNC approved symbol has changed"
-    
+
     def gene_hgnc_release_alias_symbol_change() -> str:
         return f"HGNC alias symbol has changed"
-    
+
     def gene_hgnc_release_new() -> str:
         return f"HGNC gene has been added for the first time"
-    
+
     def gene_hgnc_release_present() -> str:
         return f"HGNC gene is present in this release"
-    
+
     # transcript/gff releases
     def tx_gff_release_new() -> str:
         return f"Transcript added from a GFF release for the first time"
-    
+
     def tx_gff_release_present() -> str:
         return f"Transcript is present in this release"

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -106,8 +106,8 @@ class Command(BaseCommand):
         transcript.add_argument(
             "--hgnc_release",
             type=str,
-            help="The documented release version of the HGNC file"
-            )
+            help="The documented release version of the HGNC file",
+        )
         transcript.add_argument(
             "--mane",
             type=str,

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -104,6 +104,11 @@ class Command(BaseCommand):
             default="testing_files/hgnc_dump_20230613.txt",
         )
         transcript.add_argument(
+            "--hgnc_release",
+            type=str,
+            help="The documented release version of the HGNC file"
+            )
+        transcript.add_argument(
             "--mane",
             type=str,
             help="Path to mane .csv file",
@@ -124,6 +129,11 @@ class Command(BaseCommand):
             type=str,
             help="Path to parsed gff .tsv file",
             default="testing_files/GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv",
+        )
+        transcript.add_argument(
+            "--gff_release",
+            type=str,
+            help="The documented release version of the GFF file",
         )
         transcript.add_argument(
             "--g2refseq",
@@ -148,7 +158,7 @@ class Command(BaseCommand):
             help="The file ID of the markname csv file. Will start with 'file-'",
         )
         transcript.add_argument(
-            "--hgmd_release_label",
+            "--hgmd_release",
             type=str,
             help="The documented release version of the HGMD files",
         )
@@ -234,24 +244,25 @@ class Command(BaseCommand):
                 insert_test_directory_data(json_data, force)
 
         # python manage.py seed transcript --hgnc <path> --hgnc_release <str> --mane <path>
-        # --mane_ext_id <str> --mane_release <str> --gff <path> --g2refseq <path>
+        # --mane_ext_id <str> --mane_release <str> --gff <path> --gff_release <str> --g2refseq <path>
         # --g2refseq_ext_id <str> --markname <path> --markname_ext_id <str>
-        # --hgmd_release_label <str> --refgenome <ref_genome_version> --error
+        # --hgmd_release <str> --refgenome <ref_genome_version> --error
         elif command == "transcript":
             """
             This seeding requires the following files and strings:
             1. hgnc dump - with HGNC ID, Approved Symbol, Previous Symbols, Alias Symbols
             2. hgnc release - the in-house release version assigned to the HGNC file
-            2. MANE file csv (http://tark.ensembl.org/web/mane_GRCh37_list/)
-            3. MANE file csv - the external ID
-            4. MANE release version
-            5. parsed gff file on DNAnexus (project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gk7gZ47gypK7ZZ)
-            6. gene2refseq table from HGMD database
-            7. gene2refseq table - the external ID
-            8. markname table from HGMD database
-            9. markname table from HGMD database - the external ID
-            10. hgmd release label - in-house label assigned to this version of the data dump
-            11. reference genome - e.g. 37/38
+            3. MANE file csv (http://tark.ensembl.org/web/mane_GRCh37_list/)
+            4. MANE file's external ID (e.g. in DNAnexus)
+            5. MANE release version
+            6. parsed gff file on DNAnexus (project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gk7gZ47gypK7ZZ)
+            7. gff release - the in-house release version assigned to the GFF file
+            8. gene2refseq table from HGMD database
+            9. gene2refseq table's external ID
+            10. markname table from HGMD database
+            11. markname table's the external ID
+            12. hgmd release - in-house label assigned to this version of the data dump
+            13. reference genome - e.g. 37/38
             """
 
             # fetch input reference genome - case sensitive
@@ -265,11 +276,12 @@ class Command(BaseCommand):
             mane_ext_id = kwargs.get("mane_ext_id")
             mane_release = kwargs.get("mane_release")
             gff_file = kwargs.get("gff")
+            gff_release = kwargs.get("gff_release")
             g2refseq_file = kwargs.get("g2refseq")
             g2refseq_ext_id = kwargs.get("g2refseq_ext_id")
             markname_file = kwargs.get("markname")
             markname_ext_id = kwargs.get("markname_ext_id")
-            hgmd_release_label = kwargs.get("hgmd_release_label")
+            hgmd_release_label = kwargs.get("hgmd_release")
 
             self._validate_file_exist(
                 [
@@ -292,6 +304,7 @@ class Command(BaseCommand):
                 mane_ext_id,
                 mane_release,
                 gff_file,
+                gff_release,
                 g2refseq_file,
                 g2refseq_ext_id,
                 markname_file,

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
                 f"External file IDs {', '.join(missing_ids)} are misformatted,"
                 f" file IDs must take the format 'file-' followed by an alphanumerical string"
             )
-        
+
     def _validate_release_versions(self, releases: list[str]) -> None:
         """
         Validate that the external releases are in the correct format
@@ -309,8 +309,9 @@ class Command(BaseCommand):
 
             self._validate_ext_ids([mane_ext_id, g2refseq_ext_id, markname_ext_id])
 
-            self._validate_release_versions([hgnc_release, mane_release, gff_release,
-                                             hgmd_release])
+            self._validate_release_versions(
+                [hgnc_release, mane_release, gff_release, hgmd_release]
+            )
 
             error_log = kwargs.get("error_log", False)
 

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -198,7 +198,7 @@ class Command(BaseCommand):
         assert command, "Please specify command: panelapp / td / transcript"
 
         # TODO: fill user variable from somewhere more appropriate, like a database table
-        user = "cmd line"
+        user = "init_v1_user"
 
         # python manage.py seed panelapp <all/panel_id> <version>
         if command == "panelapp":

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -233,7 +233,7 @@ class Command(BaseCommand):
             if not test_mode:
                 insert_test_directory_data(json_data, force)
 
-        # python manage.py seed transcript --hgnc <path> --mane <path>
+        # python manage.py seed transcript --hgnc <path> --hgnc_release <str> --mane <path>
         # --mane_ext_id <str> --mane_release <str> --gff <path> --g2refseq <path>
         # --g2refseq_ext_id <str> --markname <path> --markname_ext_id <str>
         # --hgmd_release_label <str> --refgenome <ref_genome_version> --error
@@ -241,6 +241,7 @@ class Command(BaseCommand):
             """
             This seeding requires the following files and strings:
             1. hgnc dump - with HGNC ID, Approved Symbol, Previous Symbols, Alias Symbols
+            2. hgnc release - the in-house release version assigned to the HGNC file
             2. MANE file csv (http://tark.ensembl.org/web/mane_GRCh37_list/)
             3. MANE file csv - the external ID
             4. MANE release version
@@ -259,6 +260,7 @@ class Command(BaseCommand):
             print("Seeding transcripts")
 
             hgnc_file = kwargs.get("hgnc")
+            hgnc_release = kwargs.get("hgnc_release")
             mane_file = kwargs.get("mane")
             mane_ext_id = kwargs.get("mane_ext_id")
             mane_release = kwargs.get("mane_release")
@@ -285,6 +287,7 @@ class Command(BaseCommand):
 
             seed_transcripts(
                 hgnc_file,
+                hgnc_release,
                 mane_file,
                 mane_ext_id,
                 mane_release,

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -51,7 +51,21 @@ class Command(BaseCommand):
 
         if missing_ids:
             raise Exception(
-                f"External file IDs {', '.join(missing_ids)} are misformatted"
+                f"External file IDs {', '.join(missing_ids)} are misformatted,"
+                f" file IDs must take the format 'file-' followed by an alphanumerical string"
+            )
+        
+    def _validate_release_versions(self, releases: list[str]) -> None:
+        """
+        Validate that the external releases are in the correct format
+        Only numbers and dots are permitted, e.g. 1.0.13
+        """
+        invalid_releases = [id for id in releases if not re.match(r"^\d+(\.\d+)*$", id)]
+
+        if invalid_releases:
+            raise Exception(
+                f"The release versions {', '.join(invalid_releases)} are misformatted, "
+                f"release versions may only contain numbers and dots"
             )
 
     def add_arguments(self, parser) -> None:
@@ -281,7 +295,7 @@ class Command(BaseCommand):
             g2refseq_ext_id = kwargs.get("g2refseq_ext_id")
             markname_file = kwargs.get("markname")
             markname_ext_id = kwargs.get("markname_ext_id")
-            hgmd_release_label = kwargs.get("hgmd_release")
+            hgmd_release = kwargs.get("hgmd_release")
 
             self._validate_file_exist(
                 [
@@ -294,6 +308,9 @@ class Command(BaseCommand):
             )
 
             self._validate_ext_ids([mane_ext_id, g2refseq_ext_id, markname_ext_id])
+
+            self._validate_release_versions([hgnc_release, mane_release, gff_release,
+                                             hgmd_release])
 
             error_log = kwargs.get("error_log", False)
 
@@ -309,7 +326,7 @@ class Command(BaseCommand):
                 g2refseq_ext_id,
                 markname_file,
                 markname_ext_id,
-                hgmd_release_label,
+                hgmd_release,
                 ref_genome,
                 error_log,
             )

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -612,7 +612,7 @@ class TranscriptRelease(models.Model):
         default=None,
     )
 
-    external_release_version = models.CharField(
+    release = models.CharField(
         verbose_name="Transcript Release", max_length=255, null=True, default=None
     )
 
@@ -628,7 +628,7 @@ class TranscriptRelease(models.Model):
     class Meta:
         db_table = "transcript_release"
         # stop people reusing the same release version
-        unique_together = ["source", "external_release_version", "reference_genome"]
+        unique_together = ["source", "release", "reference_genome"]
 
     def __str__(self):
         return str(self.id)

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -517,7 +517,9 @@ class GeneHgncRelease(models.Model):
     Links Genes to HGNC releases if:
     - the release is where the Gene was first assigned its Symbol
     - the Gene's Symbol changed in the release
-    - The Gene's Alias changed in the release
+    - the Gene's Alias changed in the release
+    - the Gene was already in the database, and has not changed in a new release -
+    this is to show that the Gene is still present in the newer release
     """
     gene = models.ForeignKey(
         Gene,
@@ -576,6 +578,7 @@ class GeneHgncReleaseHistory(models.Model):
 
     def __str__(self):
         return str(self.id)
+   
 
 class TranscriptSource(models.Model):
     """
@@ -738,6 +741,50 @@ class TranscriptReleaseTranscript(models.Model):
     def __str__(self):
         return str(self.id)
 
+
+class GffRelease(models.Model):
+    """
+    Defines a particular release of the GFF file, the source of possibly-clinically relevant
+    transcripts.
+    """
+    gff_release = models.CharField(
+        verbose_name="Gff Release",
+        max_length=255,
+        unique=True
+    )
+    
+    class Meta:
+        db_table = "gff_release"
+
+    def __str__(self):
+        return str(self.id)
+    
+
+class TranscriptGffRelease(models.Model):
+    """
+    The link between a transcript and a GFF release.
+    This indicates that the transcript is present in that GFF release.
+    """
+    transcript = models.ForeignKey(
+        Transcript,
+        verbose_name="Transcript",
+        on_delete=models.PROTECT,
+        default=None,
+    )
+
+    gff_release = models.ForeignKey(
+        GffRelease,
+        verbose_name="Gff File Release",
+        on_delete=models.PROTECT,
+        default=None,
+    )
+
+    class Meta:
+        db_table = "transcript_gffrelease"
+        unique_together = ["transcript", "hgnc_release"]
+
+    def __str__(self):
+        return str(self.id)
 
 class PanelGene(models.Model):
     """Defines a link between a single panel and a single gene"""

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -502,6 +502,7 @@ class HgncRelease(models.Model):
     hgnc_release = models.CharField(
         verbose_name="Hgnc Release",
         max_length=255,
+        unique=True
     )
 
     class Meta:

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -689,7 +689,7 @@ class Transcript(models.Model):
 
     class Meta:
         db_table = "transcript"
-        unique_together = ("transcript", "gene", "reference_genome")
+        unique_together = ["transcript", "gene", "reference_genome"]
 
     def __str__(self):
         return str(self.id)
@@ -745,16 +745,23 @@ class TranscriptReleaseTranscript(models.Model):
 class GffRelease(models.Model):
     """
     Defines a particular release of the GFF file, the source of possibly-clinically relevant
-    transcripts.
+    transcripts. Release versions must be unique for a given reference genome.
     """
     gff_release = models.CharField(
         verbose_name="Gff Release",
         max_length=255,
         unique=True
     )
+
+    reference_genome = models.ForeignKey(
+        ReferenceGenome,
+        verbose_name="reference genome",
+        on_delete=models.PROTECT,
+    )
     
     class Meta:
         db_table = "gff_release"
+        unique_together = ["gff_release", "reference_genome"]
 
     def __str__(self):
         return str(self.id)

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -488,6 +488,88 @@ class Gene(models.Model):
         return str(self.id)
 
 
+class HgncRelease(models.Model):
+    """
+    Defines a particular release of HGNC, the source of gene IDs, symbols, and aliases
+    """
+
+    hgnc_release = models.CharField(
+        verbose_name="Hgnc Release",
+        max_length=255,
+    )
+
+    class Meta:
+        db_table = "hgnc_release"
+
+    def __str__(self):
+        return str(self.id)
+    
+
+class GeneHgncRelease(models.Model):
+    """
+    Links Genes to HGNC releases if:
+    - the release is where the Gene was first assigned its Symbol
+    - the Gene's Symbol changed in the release
+    - The Gene's Alias changed in the release
+    """
+    gene = models.ForeignKey(
+        Gene,
+        verbose_name="Gene",
+        on_delete=models.PROTECT,
+        default=None,
+    )
+
+    hgnc_release = models.ForeignKey(
+        Gene,
+        verbose_name="Gene",
+        on_delete=models.PROTECT,
+        default=None,
+    )
+
+    class Meta:
+        db_table = "gene_hgncrelease"
+        unique_together = ["gene", "hgnc_release"]
+
+    def __str__(self):
+        return str(self.id)
+   
+
+class GeneHgncReleaseHistory(models.Model):
+    """
+    Details changes to the links between Genes and particular HGNC releases, if:
+    - the release is where the Gene was first assigned its Symbol
+    - the Gene's Symbol changed in the release
+    - The Gene's Alias changed in the release
+    """
+    gene_hgnc_release = models.ForeignKey(
+        GeneHgncRelease,
+        verbose_name="Gene-HGNC Release Link",
+        on_delete=models.PROTECT,
+        default=None,
+    )
+
+    created = models.DateTimeField(
+        verbose_name="created",
+        auto_now_add=True,
+    )
+
+    note = models.CharField(
+        verbose_name="Note",
+        max_length=255,
+    )
+
+    user = models.CharField(
+        verbose_name="user",
+        max_length=255,
+        null=True,
+    )
+
+    class Meta:
+        db_table = "gene_hgncrelease_history"
+
+    def __str__(self):
+        return str(self.id)
+
 class TranscriptSource(models.Model):
     """
     Defines a particular source AND category of transcript information,

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -500,9 +500,7 @@ class HgncRelease(models.Model):
     """
 
     hgnc_release = models.CharField(
-        verbose_name="Hgnc Release",
-        max_length=255,
-        unique=True
+        verbose_name="Hgnc Release", max_length=255, unique=True
     )
 
     class Meta:
@@ -510,7 +508,7 @@ class HgncRelease(models.Model):
 
     def __str__(self):
         return str(self.id)
-    
+
 
 class GeneHgncRelease(models.Model):
     """
@@ -521,6 +519,7 @@ class GeneHgncRelease(models.Model):
     - the Gene was already in the database, and has not changed in a new release -
     this is to show that the Gene is still present in the newer release
     """
+
     gene = models.ForeignKey(
         Gene,
         verbose_name="Gene",
@@ -541,7 +540,7 @@ class GeneHgncRelease(models.Model):
 
     def __str__(self):
         return str(self.id)
-   
+
 
 class GeneHgncReleaseHistory(models.Model):
     """
@@ -550,6 +549,7 @@ class GeneHgncReleaseHistory(models.Model):
     - the Gene's Symbol changed in the release
     - The Gene's Alias changed in the release
     """
+
     gene_hgnc_release = models.ForeignKey(
         GeneHgncRelease,
         verbose_name="Gene-HGNC Release Link",
@@ -578,7 +578,7 @@ class GeneHgncReleaseHistory(models.Model):
 
     def __str__(self):
         return str(self.id)
-   
+
 
 class TranscriptSource(models.Model):
     """
@@ -747,10 +747,9 @@ class GffRelease(models.Model):
     Defines a particular release of the GFF file, the source of possibly-clinically relevant
     transcripts. Release versions must be unique for a given reference genome.
     """
+
     gff_release = models.CharField(
-        verbose_name="Gff Release",
-        max_length=255,
-        unique=True
+        verbose_name="Gff Release", max_length=255, unique=True
     )
 
     reference_genome = models.ForeignKey(
@@ -758,20 +757,21 @@ class GffRelease(models.Model):
         verbose_name="reference genome",
         on_delete=models.PROTECT,
     )
-    
+
     class Meta:
         db_table = "gff_release"
         unique_together = ["gff_release", "reference_genome"]
 
     def __str__(self):
         return str(self.id)
-    
+
 
 class TranscriptGffRelease(models.Model):
     """
     The link between a transcript and a GFF release.
     This indicates that the transcript is present in that GFF release.
     """
+
     transcript = models.ForeignKey(
         Transcript,
         verbose_name="Transcript",
@@ -792,12 +792,13 @@ class TranscriptGffRelease(models.Model):
 
     def __str__(self):
         return str(self.id)
-    
+
 
 class TranscriptGffReleaseHistory(models.Model):
     """
     Tracking history for the link between a transcript and a GFF release.
     """
+
     transcript_gff = models.ForeignKey(
         TranscriptGffRelease,
         verbose_name="Transcript Gff",

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -788,10 +788,45 @@ class TranscriptGffRelease(models.Model):
 
     class Meta:
         db_table = "transcript_gffrelease"
-        unique_together = ["transcript", "hgnc_release"]
+        unique_together = ["transcript", "gff_release"]
 
     def __str__(self):
         return str(self.id)
+    
+
+class TranscriptGffReleaseHistory(models.Model):
+    """
+    Tracking history for the link between a transcript and a GFF release.
+    """
+    transcript_gff = models.ForeignKey(
+        TranscriptGffRelease,
+        verbose_name="Transcript Gff",
+        on_delete=models.PROTECT,
+        default=None,
+    )
+
+    created = models.DateTimeField(
+        verbose_name="created",
+        auto_now_add=True,
+    )
+
+    note = models.CharField(
+        verbose_name="Note",
+        max_length=255,
+    )
+
+    user = models.CharField(
+        verbose_name="user",
+        max_length=255,
+        null=True,
+    )
+
+    class Meta:
+        db_table = "transcript_gff_file_history"
+
+    def __str__(self):
+        return str(self.id)
+
 
 class PanelGene(models.Model):
     """Defines a link between a single panel and a single gene"""

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -526,8 +526,8 @@ class GeneHgncRelease(models.Model):
     )
 
     hgnc_release = models.ForeignKey(
-        Gene,
-        verbose_name="Gene",
+        HgncRelease,
+        verbose_name="Hgnc Release",
         on_delete=models.PROTECT,
         default=None,
     )
@@ -571,7 +571,7 @@ class GeneHgncReleaseHistory(models.Model):
     )
 
     class Meta:
-        db_table = "gene_hgncrelease_history"
+        db_table = "gene_hgnc_release_history"
 
     def __str__(self):
         return str(self.id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ exceptiongroup==1.1.3
 gunicorn==21.2.0
 idna==3.4
 iniconfig==2.0.0
-looseversion==1.3.0
 model-bakery==1.15.0
 mypy-extensions==1.0.0
 numpy==1.24.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ exceptiongroup==1.1.3
 gunicorn==21.2.0
 idna==3.4
 iniconfig==2.0.0
+looseversion==1.3.0
 model-bakery==1.15.0
 mypy-extensions==1.0.0
 numpy==1.24.3

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_categorisation_to_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_categorisation_to_db.py
@@ -34,18 +34,18 @@ class TestTranscriptAdded_FromScratch(TestCase):
 
         self.select_release = TranscriptRelease.objects.create(
             source=select,
-            external_release_version="version_3",
+            release="version_3",
             reference_genome=ref_genome,
         )
 
         self.plus_release = TranscriptRelease.objects.create(
             source=plus,
-            external_release_version="version_3",
+            release="version_3",
             reference_genome=ref_genome,
         )
 
         self.hgmd_release = TranscriptRelease.objects.create(
-            source=hgmd, external_release_version="v2", reference_genome=ref_genome
+            source=hgmd, release="v2", reference_genome=ref_genome
         )
 
     def test_new_transcript(self):
@@ -113,34 +113,34 @@ class TestTranscriptAdded_PreexistingReleases(TestCase):
 
         self.select_old = TranscriptRelease.objects.create(
             source=select,
-            external_release_version="version_3",
+            release="version_3",
             reference_genome=ref_genome,
         )
 
         self.plus_old = TranscriptRelease.objects.create(
             source=plus,
-            external_release_version="version_3",
+            release="version_3",
             reference_genome=ref_genome,
         )
 
         self.hgmd_old = TranscriptRelease.objects.create(
-            source=hgmd, external_release_version="v2", reference_genome=ref_genome
+            source=hgmd, release="v2", reference_genome=ref_genome
         )
 
         self.select_new = TranscriptRelease.objects.create(
             source=select,
-            external_release_version="version_4",
+            release="version_4",
             reference_genome=ref_genome,
         )
 
         self.plus_new = TranscriptRelease.objects.create(
             source=plus,
-            external_release_version="version_4",
+            release="version_4",
             reference_genome=ref_genome,
         )
 
         self.hgmd_new = TranscriptRelease.objects.create(
-            source=hgmd, external_release_version="v3", reference_genome=ref_genome
+            source=hgmd, release="v3", reference_genome=ref_genome
         )
 
         self.select_old_link = TranscriptReleaseTranscript.objects.create(

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_release_info_to_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_release_info_to_db.py
@@ -63,7 +63,7 @@ class TestAddTranscriptRelease_FromScratch(TestCase):
         err += value_check_wrapper(file_1.file_id, "file ID 1", "file-1357")
         err += value_check_wrapper(file_2.file_id, "file ID 2", "file-101010")
         err += value_check_wrapper(
-            release.external_release_version, "release", "v1.2.3"
+            release.release, "release", "v1.2.3"
         )
         err += value_check_wrapper(
             rel_file_link_1.transcript_release, "release-file link 1", release
@@ -98,7 +98,7 @@ class TestAddTranscriptRelease_ErrorsOnVersionRepeatsWithDifferentFiles(TestCase
         self.source = TranscriptSource.objects.create(source="HGMD")
         self.release = TranscriptRelease.objects.create(
             source=self.source,
-            external_release_version="v1.0.5",
+            release="v1.0.5",
             reference_genome=self.reference_genome,
         )
 
@@ -140,7 +140,7 @@ class TestAddTranscriptRelease_SameFilesNoProblem(TestCase):
         self.source = TranscriptSource.objects.create(source="HGMD")
         self.release = TranscriptRelease.objects.create(
             source=self.source,
-            external_release_version="v1.0.5",
+            release="v1.0.5",
             reference_genome=self.reference_genome,
         )
         self.file_one = TranscriptFile.objects.create(file_id="123", file_type="test")
@@ -183,7 +183,7 @@ class TestAddTranscriptRelease_CheckNotMissingFiles(TestCase):
         self.source = TranscriptSource.objects.create(source="HGMD")
         self.release = TranscriptRelease.objects.create(
             source=self.source,
-            external_release_version="v1.0.5",
+            release="v1.0.5",
             reference_genome=self.reference_genome,
         )
         self.file_one = TranscriptFile.objects.create(file_id="123", file_type="test")

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_release_info_to_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_release_info_to_db.py
@@ -62,9 +62,7 @@ class TestAddTranscriptRelease_FromScratch(TestCase):
         err += value_check_wrapper(source.source, "source name", "MANE Select")
         err += value_check_wrapper(file_1.file_id, "file ID 1", "file-1357")
         err += value_check_wrapper(file_2.file_id, "file ID 2", "file-101010")
-        err += value_check_wrapper(
-            release.release, "release", "v1.2.3"
-        )
+        err += value_check_wrapper(release.release, "release", "v1.2.3")
         err += value_check_wrapper(
             rel_file_link_1.transcript_release, "release-file link 1", release
         )

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -1,0 +1,179 @@
+from django.test import TestCase
+
+import numpy as np
+
+from requests_app.models import (
+    Gene,
+    Transcript,
+    GffRelease,
+    TranscriptGffRelease,
+    TranscriptGffReleaseHistory,
+    ReferenceGenome,
+)
+from requests_app.management.commands.history import History
+from requests_app.management.commands._parse_transcript import (
+    _add_transcript_to_db_with_gff_release
+)
+from tests.tests_requests_app.test_management.test_commands.test_insert_panel.test_insert_gene import (
+    len_check_wrapper,
+    value_check_wrapper,
+)
+
+
+class TestAddTranscriptWithGff_NewTranscript(TestCase):
+    """
+    Emulate the case where a brand new transcript is being added to
+    the database for the first time.
+    """
+    def setUp(self) -> None:
+        self.gene, _ = Gene.objects.get_or_create(
+            hgnc_id="HGNC:1034",
+            gene_symbol="ABC1",
+            alias_symbols="GET1,AND1"
+        )
+
+        self.transcript_name = "NM04582.5"
+
+        self.ref_genome, _ = ReferenceGenome.objects.get_or_create(
+            reference_genome="GRCh37"
+        )
+
+        self.gff_release, _ = GffRelease.objects.get_or_create(
+            gff_release="v10.2",
+            reference_genome=self.ref_genome
+        )
+
+        self.user="Andy Test"
+
+    def test_novel_transcript_links_successfully(self):
+        """
+        CASE: A new transcript needs adding to the database
+        EXPECT: Tx adds, links to currently-provided GFF release, and logs history
+        saying this is a brand new transcript with a link.
+        """
+        err = []
+
+        tx = _add_transcript_to_db_with_gff_release(
+            self.gene,
+            self.transcript_name,
+            self.ref_genome,
+            self.gff_release,
+            self.user
+        )
+
+        tx = Transcript.objects.all()
+        err += len_check_wrapper(tx, "transcripts created", 1)
+        err += value_check_wrapper(tx[0].transcript, "transcript name", self.transcript_name)
+
+        release = GffRelease.objects.all()
+        err += len_check_wrapper(release, "releases", 1)
+        err += value_check_wrapper(release[0].gff_release, "release version", "v10.2")
+
+        tx_release = TranscriptGffRelease.objects.all()
+        err += len_check_wrapper(tx_release, "tx-release links", 1)
+        err += value_check_wrapper(tx_release[0].transcript, "linked tx", tx[0])
+        err += value_check_wrapper(tx_release[0].gff_release, "linked release", release[0])
+
+        history = TranscriptGffReleaseHistory.objects.all()
+        err += len_check_wrapper(history, "history", 1)
+        err += value_check_wrapper(history[0].transcript_gff, "tx-release", tx_release[0])
+        err += value_check_wrapper(history[0].note, "tx-release note", History.tx_gff_release_new())
+
+        errors = "; ".join(err)
+        assert not errors, errors
+
+
+class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
+    """
+    Emulate cases where a transcript is already in the database,
+    but we need to link it to this GFF release for the first time.
+    """
+    def setUp(self) -> None:
+        self.gene, _ = Gene.objects.get_or_create(
+            hgnc_id="HGNC:1034",
+            gene_symbol="ABC1",
+            alias_symbols="GET1,AND1"
+        )
+
+        self.transcript_name = "NM04582.5"
+
+        self.ref_genome, _ = ReferenceGenome.objects.get_or_create(
+            reference_genome="GRCh37"
+        )
+
+        self.gff_release, _ = GffRelease.objects.get_or_create(
+            gff_release="v10.2",
+            reference_genome=self.ref_genome
+        )
+
+        self.transcript, _ = Transcript.objects.get_or_create(
+            transcript = self.transcript_name,
+            gene=self.gene,
+            reference_genome=self.ref_genome
+        )
+
+        self.user="Andy Test"
+
+    def test_existing_transcript_links_successfully(self):
+        """
+        CASE: A transcript already exists in the database, possibly from an earlier GFF release.
+        EXPECT: Existing tx links to currently-provided GFF release, and logs history
+        saying this is an already-present transcript.
+        """
+        err = []
+
+        tx = _add_transcript_to_db_with_gff_release(
+            self.gene,
+            self.transcript_name,
+            self.ref_genome,
+            self.gff_release,
+            self.user
+        )
+
+        tx = Transcript.objects.all()
+        err += len_check_wrapper(tx, "transcripts created", 1)
+        err += value_check_wrapper(tx[0].transcript, "transcript name", self.transcript_name)
+
+        release = GffRelease.objects.all()
+        err += len_check_wrapper(release, "releases", 1)
+        err += value_check_wrapper(release[0].gff_release, "release version", "v10.2")
+
+        tx_release = TranscriptGffRelease.objects.all()
+        err += len_check_wrapper(tx_release, "tx-release links", 1)
+        err += value_check_wrapper(tx_release[0].transcript, "linked tx", tx[0])
+        err += value_check_wrapper(tx_release[0].gff_release, "linked release", release[0])
+
+        history = TranscriptGffReleaseHistory.objects.all()
+        err += len_check_wrapper(history, "history", 1)
+        err += value_check_wrapper(history[0].transcript_gff, "tx-release", tx_release[0])
+        err += value_check_wrapper(history[0].note, "tx-release note", History.tx_gff_release_present())
+
+        errors = "; ".join(err)
+        assert not errors, errors
+
+    def test_existing_transcript_existing_gff_link_ignored(self):
+        """
+        CASE: A transcript already exists in the database, and so does this GFF release.
+        EXPECT: Existing tx-gff link is retrieved. History isn't logged as it's redundant.
+        """
+        err = []
+
+        # make it so that the tx/gff are already linked:
+        self.existing_link, _ = TranscriptGffRelease.objects.get_or_create(
+            transcript=self.transcript,
+            gff_release=self.gff_release
+        )
+
+        tx = _add_transcript_to_db_with_gff_release(
+            self.gene,
+            self.transcript_name,
+            self.ref_genome,
+            self.gff_release,
+            self.user
+        )
+
+        history = TranscriptGffReleaseHistory.objects.all()
+        err += len_check_wrapper(history, "history", 0)
+
+        errors = "; ".join(err)
+        assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -12,7 +12,7 @@ from requests_app.models import (
 )
 from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import (
-    _add_transcript_to_db_with_gff_release
+    _add_transcript_to_db_with_gff_release,
 )
 from tests.tests_requests_app.test_management.test_commands.test_insert_panel.test_insert_gene import (
     len_check_wrapper,
@@ -25,11 +25,10 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
     Emulate the case where a brand new transcript is being added to
     the database for the first time.
     """
+
     def setUp(self) -> None:
         self.gene, _ = Gene.objects.get_or_create(
-            hgnc_id="HGNC:1034",
-            gene_symbol="ABC1",
-            alias_symbols="GET1,AND1"
+            hgnc_id="HGNC:1034", gene_symbol="ABC1", alias_symbols="GET1,AND1"
         )
 
         self.transcript_name = "NM04582.5"
@@ -39,11 +38,10 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
         )
 
         self.gff_release, _ = GffRelease.objects.get_or_create(
-            gff_release="v10.2",
-            reference_genome=self.ref_genome
+            gff_release="v10.2", reference_genome=self.ref_genome
         )
 
-        self.user="Andy Test"
+        self.user = "Andy Test"
 
     def test_novel_transcript_links_successfully(self):
         """
@@ -58,12 +56,14 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
             self.transcript_name,
             self.ref_genome,
             self.gff_release,
-            self.user
+            self.user,
         )
 
         tx = Transcript.objects.all()
         err += len_check_wrapper(tx, "transcripts created", 1)
-        err += value_check_wrapper(tx[0].transcript, "transcript name", self.transcript_name)
+        err += value_check_wrapper(
+            tx[0].transcript, "transcript name", self.transcript_name
+        )
 
         release = GffRelease.objects.all()
         err += len_check_wrapper(release, "releases", 1)
@@ -72,12 +72,18 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
         tx_release = TranscriptGffRelease.objects.all()
         err += len_check_wrapper(tx_release, "tx-release links", 1)
         err += value_check_wrapper(tx_release[0].transcript, "linked tx", tx[0])
-        err += value_check_wrapper(tx_release[0].gff_release, "linked release", release[0])
+        err += value_check_wrapper(
+            tx_release[0].gff_release, "linked release", release[0]
+        )
 
         history = TranscriptGffReleaseHistory.objects.all()
         err += len_check_wrapper(history, "history", 1)
-        err += value_check_wrapper(history[0].transcript_gff, "tx-release", tx_release[0])
-        err += value_check_wrapper(history[0].note, "tx-release note", History.tx_gff_release_new())
+        err += value_check_wrapper(
+            history[0].transcript_gff, "tx-release", tx_release[0]
+        )
+        err += value_check_wrapper(
+            history[0].note, "tx-release note", History.tx_gff_release_new()
+        )
 
         errors = "; ".join(err)
         assert not errors, errors
@@ -88,11 +94,10 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
     Emulate cases where a transcript is already in the database,
     but we need to link it to this GFF release for the first time.
     """
+
     def setUp(self) -> None:
         self.gene, _ = Gene.objects.get_or_create(
-            hgnc_id="HGNC:1034",
-            gene_symbol="ABC1",
-            alias_symbols="GET1,AND1"
+            hgnc_id="HGNC:1034", gene_symbol="ABC1", alias_symbols="GET1,AND1"
         )
 
         self.transcript_name = "NM04582.5"
@@ -102,17 +107,16 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
         )
 
         self.gff_release, _ = GffRelease.objects.get_or_create(
-            gff_release="v10.2",
-            reference_genome=self.ref_genome
+            gff_release="v10.2", reference_genome=self.ref_genome
         )
 
         self.transcript, _ = Transcript.objects.get_or_create(
-            transcript = self.transcript_name,
+            transcript=self.transcript_name,
             gene=self.gene,
-            reference_genome=self.ref_genome
+            reference_genome=self.ref_genome,
         )
 
-        self.user="Andy Test"
+        self.user = "Andy Test"
 
     def test_existing_transcript_links_successfully(self):
         """
@@ -127,12 +131,14 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
             self.transcript_name,
             self.ref_genome,
             self.gff_release,
-            self.user
+            self.user,
         )
 
         tx = Transcript.objects.all()
         err += len_check_wrapper(tx, "transcripts created", 1)
-        err += value_check_wrapper(tx[0].transcript, "transcript name", self.transcript_name)
+        err += value_check_wrapper(
+            tx[0].transcript, "transcript name", self.transcript_name
+        )
 
         release = GffRelease.objects.all()
         err += len_check_wrapper(release, "releases", 1)
@@ -141,12 +147,18 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
         tx_release = TranscriptGffRelease.objects.all()
         err += len_check_wrapper(tx_release, "tx-release links", 1)
         err += value_check_wrapper(tx_release[0].transcript, "linked tx", tx[0])
-        err += value_check_wrapper(tx_release[0].gff_release, "linked release", release[0])
+        err += value_check_wrapper(
+            tx_release[0].gff_release, "linked release", release[0]
+        )
 
         history = TranscriptGffReleaseHistory.objects.all()
         err += len_check_wrapper(history, "history", 1)
-        err += value_check_wrapper(history[0].transcript_gff, "tx-release", tx_release[0])
-        err += value_check_wrapper(history[0].note, "tx-release note", History.tx_gff_release_present())
+        err += value_check_wrapper(
+            history[0].transcript_gff, "tx-release", tx_release[0]
+        )
+        err += value_check_wrapper(
+            history[0].note, "tx-release note", History.tx_gff_release_present()
+        )
 
         errors = "; ".join(err)
         assert not errors, errors
@@ -160,8 +172,7 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
 
         # make it so that the tx/gff are already linked:
         self.existing_link, _ = TranscriptGffRelease.objects.get_or_create(
-            transcript=self.transcript,
-            gff_release=self.gff_release
+            transcript=self.transcript, gff_release=self.gff_release
         )
 
         tx = _add_transcript_to_db_with_gff_release(
@@ -169,7 +180,7 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
             self.transcript_name,
             self.ref_genome,
             self.gff_release,
-            self.user
+            self.user,
         )
 
         history = TranscriptGffReleaseHistory.objects.all()

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -1,7 +1,5 @@
 from django.test import TestCase
 
-import numpy as np
-
 from requests_app.models import (
     Gene,
     Transcript,

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -39,7 +39,7 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
             gff_release="v10.2", reference_genome=self.ref_genome
         )
 
-        self.user = "Andy Test"
+        self.user = "init_v1_user"
 
     def test_novel_transcript_links_successfully(self):
         """
@@ -114,7 +114,7 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
             reference_genome=self.ref_genome,
         )
 
-        self.user = "Andy Test"
+        self.user = "init_v1_user"
 
     def test_existing_transcript_links_successfully(self):
         """

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
@@ -8,36 +8,53 @@ from requests_app.models import (
     GffRelease,
     TranscriptRelease,
     TranscriptSource,
-    ReferenceGenome
+    ReferenceGenome,
 )
 from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import (
     _check_for_transcript_seeding_version_regression,
 )
 
+
 class TestCheckRegressions_OldHgncRelease(TestCase):
     """
     Check errors are thrown if a HGNC release
     provided by a user, is too old
     """
+
     def setUp(self) -> None:
         # set up TranscriptSources and ref genome
         self.hgmd_source = TranscriptSource.objects.create(source="HGMD")
         self.mane_select_source = TranscriptSource.objects.create(source="MANE Select")
-        self.mane_plus_source = TranscriptSource.objects.create(source="MANE Plus Clinical")
+        self.mane_plus_source = TranscriptSource.objects.create(
+            source="MANE Plus Clinical"
+        )
 
-        self.reference_genome = ReferenceGenome.objects.create(reference_genome="GRCh37")
+        self.reference_genome = ReferenceGenome.objects.create(
+            reference_genome="GRCh37"
+        )
 
         # pre-populate releases
         self.hgnc = HgncRelease.objects.create(hgnc_release="2")
-        self.gff = GffRelease.objects.create(gff_release="1.0", reference_genome=self.reference_genome)
-        self.gff_2 = GffRelease.objects.create(gff_release="0.5", reference_genome=self.reference_genome)
-        self.mane_select = TranscriptRelease.objects.create(release="2", source=self.mane_select_source,
-                                                            reference_genome=self.reference_genome)
-        self.mane_plus = TranscriptRelease.objects.create(release="2", source=self.mane_plus_source,
-                                                            reference_genome=self.reference_genome)
-        self.hgmd = TranscriptRelease.objects.create(release="2", source=self.hgmd_source,
-                                                     reference_genome=self.reference_genome)
+        self.gff = GffRelease.objects.create(
+            gff_release="1.0", reference_genome=self.reference_genome
+        )
+        self.gff_2 = GffRelease.objects.create(
+            gff_release="0.5", reference_genome=self.reference_genome
+        )
+        self.mane_select = TranscriptRelease.objects.create(
+            release="2",
+            source=self.mane_select_source,
+            reference_genome=self.reference_genome,
+        )
+        self.mane_plus = TranscriptRelease.objects.create(
+            release="2",
+            source=self.mane_plus_source,
+            reference_genome=self.reference_genome,
+        )
+        self.hgmd = TranscriptRelease.objects.create(
+            release="2", source=self.hgmd_source, reference_genome=self.reference_genome
+        )
 
     def test_one_old_release(self):
         """
@@ -49,11 +66,14 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
         new_gff = 1.0
         new_mane = 2
         new_hgmd = 2.1
-        
-        expected_err = "Abandoning input because: hgnc release is a lower version than 2"
+
+        expected_err = (
+            "Abandoning input because: hgnc release is a lower version than 2"
+        )
         with self.assertRaises(ValueError) as err:
-            _check_for_transcript_seeding_version_regression(new_hgnc, new_gff, new_mane,
-                                                        new_hgmd, self.reference_genome)
+            _check_for_transcript_seeding_version_regression(
+                new_hgnc, new_gff, new_mane, new_hgmd, self.reference_genome
+            )
         self.assertEquals(str(err.exception), expected_err)
 
     def test_multiple_old_releases(self):
@@ -62,23 +82,28 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
         are too old
         EXPECT: Exception raised with an error for the affected releases only.
         """
-        new_hgnc = "1" #too old
+        new_hgnc = "1"  # too old
         new_gff = "1.0"
         new_mane = "2"
-        new_hgmd = "1.9.0" #too old, uses subversioning
-        
+        new_hgmd = "1.9.0"  # too old, uses subversioning
+
         expected_err = "Abandoning input because: hgnc release is a lower version than 2; gff release is a lower version than 1.0"
         with self.assertRaises(ValueError) as err:
-            _check_for_transcript_seeding_version_regression(new_hgnc, new_gff, new_mane,
-                                                        new_hgmd, self.reference_genome)
+            _check_for_transcript_seeding_version_regression(
+                new_hgnc, new_gff, new_mane, new_hgmd, self.reference_genome
+            )
         self.assertEquals(str(err.exception), expected_err)
+
 
 class TestCheckRegressions_NoReleasesYet(TestCase):
     """
     Check versions are accepted if the database starts empty
     """
+
     def setUp(self) -> None:
-        self.reference_genome = ReferenceGenome.objects.create(reference_genome="GRCh38")
+        self.reference_genome = ReferenceGenome.objects.create(
+            reference_genome="GRCh38"
+        )
 
     def test_fresh_db(self):
         """
@@ -90,7 +115,7 @@ class TestCheckRegressions_NoReleasesYet(TestCase):
         new_gff = "1.0"
         new_mane = "2"
         new_hgmd = "1.9.0"
-        
-        _check_for_transcript_seeding_version_regression(new_hgnc, new_gff, new_mane,
-                                                        new_hgmd, self.reference_genome)
-        
+
+        _check_for_transcript_seeding_version_regression(
+            new_hgnc, new_gff, new_mane, new_hgmd, self.reference_genome
+        )

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
@@ -1,0 +1,34 @@
+from typing import Any
+from django.test import TestCase
+
+import numpy as np
+
+from requests_app.models import (
+    HgncRelease,
+    GffRelease,
+    TranscriptRelease,
+    TranscriptSource,
+)
+from requests_app.management.commands.history import History
+from requests_app.management.commands._parse_transcript import (
+    _check_for_transcript_seeding_version_regression,
+)
+from tests.tests_requests_app.test_management.test_commands.test_insert_panel.test_insert_gene import (
+    len_check_wrapper,
+    value_check_wrapper,
+)
+
+class TestCheckRegressions_OldHgncRelease(TestCase):
+    """
+    Check errors are thrown if a HGNC release
+    provided by a user, is too old
+    """
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def test_old_hgnc_release(self):
+        """
+        CASE: All user-provided releases are newer/same age as in db, EXCEPT the HGNC release
+        is too old.
+        EXPECT: Exception raised with an error for the HGNC release
+        """

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
@@ -25,15 +25,35 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
     provided by a user, is too old
     """
     def setUp(self) -> None:
+        # set up TranscriptSources and ref genome
+        self.hgmd_source = TranscriptSource.objects.create(source="HGMD")
+        self.mane_select_source = TranscriptSource.objects.create(source="MANE Select")
+        self.mane_plus_source = TranscriptSource.objects.create(source="MANE Plus Clinical")
+
         self.reference_genome = ReferenceGenome.objects.create(reference_genome="GRCh37")
 
+        # pre-populate releases
         self.hgnc = HgncRelease.objects.create(hgnc_release="2")
         self.gff = GffRelease.objects.create(gff_release="1.0", reference_genome=self.reference_genome)
-        self.mane_select = TranscriptRelease.objects.create()
-    
-    def test_old_hgnc_release(self):
+        self.mane_select = TranscriptRelease.objects.create(release="2", source=self.mane_select_source,
+                                                            reference_genome=self.reference_genome)
+        self.mane_plus = TranscriptRelease.objects.create(release="2", source=self.mane_plus_source,
+                                                            reference_genome=self.reference_genome)
+        self.hgmd = TranscriptRelease.objects.create(release="2", source=self.hgmd_source,
+                                                     reference_genome=self.reference_genome)
+
+    def test_one_old_release(self):
         """
         CASE: All user-provided releases are newer/same age as in db, EXCEPT the HGNC release
         is too old.
         EXPECT: Exception raised with an error for the HGNC release
         """
+        new_hgnc = 1
+        new_gff = 1.0
+        new_mane = 2
+        new_hgmd = 2.1
+        
+        expected_err = "Abandoning input because: hgnc release is a lower version than 2"
+        with self.assertRaisesRegex(ValueError, expected_err):
+            _check_for_transcript_seeding_version_regression(new_hgnc, new_gff, new_mane,
+                                                        new_hgmd, self.reference_genome)

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
@@ -8,6 +8,7 @@ from requests_app.models import (
     GffRelease,
     TranscriptRelease,
     TranscriptSource,
+    ReferenceGenome
 )
 from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import (
@@ -24,7 +25,11 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
     provided by a user, is too old
     """
     def setUp(self) -> None:
-        return super().setUp()
+        self.reference_genome = ReferenceGenome.objects.create(reference_genome="GRCh37")
+
+        self.hgnc = HgncRelease.objects.create(hgnc_release="2")
+        self.gff = GffRelease.objects.create(gff_release="1.0", reference_genome=self.reference_genome)
+        self.mane_select = TranscriptRelease.objects.create()
     
     def test_old_hgnc_release(self):
         """

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
@@ -1,15 +1,16 @@
 from django.test import TestCase
 
+from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import _add_new_genes_to_db
 from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
-    len_check_wrapper,
+    len_check_wrapper, value_check_wrapper
 )
 from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
 
 
 class TestGetOrCreate_CreateNew(TestCase):
     """
-    Just emulates straightforward entry of new genes
+    CASE: Just emulates straightforward entry of new genes
     EXPECT: single entry in the database for each gene
     """
 
@@ -39,6 +40,70 @@ class TestGetOrCreate_CreateNew(TestCase):
                 errors.append(
                     f"Post run gene {post_run_genes[i].alias_symbols} not in {poss_aliases}"
                 )
+
+        # check HGNC release logging was correctly carried out
+        post_run_hgnc_release_links = GeneHgncRelease.objects.all()
+        errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 2)
+        for i in range(len(post_run_hgnc_release_links)):
+            errors += value_check_wrapper(post_run_hgnc_release_links[i].hgnc_release,
+                                          "linked release",
+                                          self.hgnc_release)
+
+        post_run_history = GeneHgncReleaseHistory.objects.all()
+        for i in range(len(post_run_history)):
+            errors += len_check_wrapper(post_run_history[i].note,
+                                        "linked history",
+                                        note=History.gene_hgnc_release_new)
+
+        errors = "; ".join(errors)
+        assert not errors, errors
+
+class TestGetOrCreate_AllGenesExistAlready(TestCase):
+    """
+    CASE: All the genes in the HGNC file, already exist in the database
+    EXPECT: The gene entry isn't made, but it is linked to the new release
+    """
+
+    def setUp(self) -> None:
+        self.hgnc_release = HgncRelease.objects.create(hgnc_release="new_hgnc")
+        self.user = "test user"
+
+    def test_adding_identical_gene(self):
+        errors = []
+
+        approved_symbols = {"HGNC:10257": "ROR2", "HGNC:TEST": "TEST_SYMBOL"}
+        alias_symbols = {"HGNC:10257": None, "HGNC:TEST": "TEST, ALIAS"}
+
+        _add_new_genes_to_db(approved_symbols, alias_symbols, self.hgnc_release, self.user)
+
+        post_run_genes = Gene.objects.all()
+        errors += len_check_wrapper(post_run_genes, "number of post run genes", 2)
+
+        poss_symbols = ["ROR2", "TEST_SYMBOL"]
+        poss_aliases = [None, "TEST, ALIAS"]
+        for i in range(0, 2, 1):
+            if not post_run_genes[i].gene_symbol in poss_symbols:
+                errors.append(
+                    f"Post run gene {post_run_genes[i].gene_symbol} not in {poss_symbols}"
+                )
+            if not post_run_genes[i].alias_symbols in poss_aliases:
+                errors.append(
+                    f"Post run gene {post_run_genes[i].alias_symbols} not in {poss_aliases}"
+                )
+
+        # check HGNC release logging was correctly carried out
+        post_run_hgnc_release_links = GeneHgncRelease.objects.all()
+        errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 2)
+        for i in range(len(post_run_hgnc_release_links)):
+            errors += value_check_wrapper(post_run_hgnc_release_links[i].hgnc_release,
+                                          "linked release",
+                                          self.hgnc_release)
+
+        post_run_history = GeneHgncReleaseHistory.objects.all()
+        for i in range(len(post_run_history)):
+            errors += len_check_wrapper(post_run_history[i].note,
+                                        "linked history",
+                                        note=History.gene_hgnc_release_new)
 
         errors = "; ".join(errors)
         assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
@@ -4,7 +4,7 @@ from requests_app.management.commands._parse_transcript import _add_new_genes_to
 from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
     len_check_wrapper,
 )
-from requests_app.models import Gene
+from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
 
 
 class TestGetOrCreate_CreateNew(TestCase):
@@ -14,7 +14,8 @@ class TestGetOrCreate_CreateNew(TestCase):
     """
 
     def setUp(self) -> None:
-        pass
+        self.hgnc_release = HgncRelease.objects.create(hgnc_release="new_hgnc")
+        self.user = "test user"
 
     def test_adding_identical_gene(self):
         errors = []
@@ -22,7 +23,7 @@ class TestGetOrCreate_CreateNew(TestCase):
         approved_symbols = {"HGNC:10257": "ROR2", "HGNC:TEST": "TEST_SYMBOL"}
         alias_symbols = {"HGNC:10257": None, "HGNC:TEST": "TEST, ALIAS"}
 
-        _add_new_genes_to_db(approved_symbols, alias_symbols)
+        _add_new_genes_to_db(approved_symbols, alias_symbols, self.hgnc_release, self.user)
 
         post_run_genes = Gene.objects.all()
         errors += len_check_wrapper(post_run_genes, "number of post run genes", 2)

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
@@ -3,9 +3,15 @@ from django.test import TestCase
 from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import _add_new_genes_to_db
 from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
-    len_check_wrapper, value_check_wrapper
+    len_check_wrapper,
+    value_check_wrapper,
 )
-from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
+from requests_app.models import (
+    Gene,
+    HgncRelease,
+    GeneHgncRelease,
+    GeneHgncReleaseHistory,
+)
 
 
 class TestGetOrCreate_CreateNew(TestCase):
@@ -21,8 +27,10 @@ class TestGetOrCreate_CreateNew(TestCase):
     def test_adding_new_gene(self):
         errors = []
 
-        input = [{"hgnc_id": "HGNC:10257", "symbol": "ROR2", "alias": None },
-                 {"hgnc_id": "HGNC:TEST", "symbol": "TEST_SYMBOL", "alias": "TEST, ALIAS"}]
+        input = [
+            {"hgnc_id": "HGNC:10257", "symbol": "ROR2", "alias": None},
+            {"hgnc_id": "HGNC:TEST", "symbol": "TEST_SYMBOL", "alias": "TEST, ALIAS"},
+        ]
 
         _add_new_genes_to_db(input, self.hgnc_release, self.user)
 
@@ -43,20 +51,26 @@ class TestGetOrCreate_CreateNew(TestCase):
 
         # check HGNC release logging was correctly carried out
         post_run_hgnc_release_links = GeneHgncRelease.objects.all()
-        errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 2)
+        errors += len_check_wrapper(
+            post_run_hgnc_release_links, "number of release links", 2
+        )
 
         for i in range(len(post_run_hgnc_release_links)):
-            errors += value_check_wrapper(post_run_hgnc_release_links[i].hgnc_release,
-                                          "linked release",
-                                          self.hgnc_release)
+            errors += value_check_wrapper(
+                post_run_hgnc_release_links[i].hgnc_release,
+                "linked release",
+                self.hgnc_release,
+            )
 
         post_run_history = GeneHgncReleaseHistory.objects.all()
         errors += len_check_wrapper(post_run_history, "number of history entries", 2)
 
         for i in range(len(post_run_history)):
-            errors += value_check_wrapper(post_run_history[i].note,
-                                        "linked history",
-                                        History.gene_hgnc_release_new())
+            errors += value_check_wrapper(
+                post_run_history[i].note,
+                "linked history",
+                History.gene_hgnc_release_new(),
+            )
 
         errors = "; ".join(errors)
         assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
@@ -44,16 +44,19 @@ class TestGetOrCreate_CreateNew(TestCase):
         # check HGNC release logging was correctly carried out
         post_run_hgnc_release_links = GeneHgncRelease.objects.all()
         errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 2)
+
         for i in range(len(post_run_hgnc_release_links)):
             errors += value_check_wrapper(post_run_hgnc_release_links[i].hgnc_release,
                                           "linked release",
                                           self.hgnc_release)
 
         post_run_history = GeneHgncReleaseHistory.objects.all()
+        errors += len_check_wrapper(post_run_history, "number of history entries", 2)
+
         for i in range(len(post_run_history)):
-            errors += len_check_wrapper(post_run_history[i].note,
+            errors += value_check_wrapper(post_run_history[i].note,
                                         "linked history",
-                                        note=History.gene_hgnc_release_new)
+                                        History.gene_hgnc_release_new())
 
         errors = "; ".join(errors)
         assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
@@ -18,63 +18,13 @@ class TestGetOrCreate_CreateNew(TestCase):
         self.hgnc_release = HgncRelease.objects.create(hgnc_release="new_hgnc")
         self.user = "test user"
 
-    def test_adding_identical_gene(self):
+    def test_adding_new_gene(self):
         errors = []
 
-        approved_symbols = {"HGNC:10257": "ROR2", "HGNC:TEST": "TEST_SYMBOL"}
-        alias_symbols = {"HGNC:10257": None, "HGNC:TEST": "TEST, ALIAS"}
+        input = [{"hgnc_id": "HGNC:10257", "symbol": "ROR2", "alias": None },
+                 {"hgnc_id": "HGNC:TEST", "symbol": "TEST_SYMBOL", "alias": "TEST, ALIAS"}]
 
-        _add_new_genes_to_db(approved_symbols, alias_symbols, self.hgnc_release, self.user)
-
-        post_run_genes = Gene.objects.all()
-        errors += len_check_wrapper(post_run_genes, "number of post run genes", 2)
-
-        poss_symbols = ["ROR2", "TEST_SYMBOL"]
-        poss_aliases = [None, "TEST, ALIAS"]
-        for i in range(0, 2, 1):
-            if not post_run_genes[i].gene_symbol in poss_symbols:
-                errors.append(
-                    f"Post run gene {post_run_genes[i].gene_symbol} not in {poss_symbols}"
-                )
-            if not post_run_genes[i].alias_symbols in poss_aliases:
-                errors.append(
-                    f"Post run gene {post_run_genes[i].alias_symbols} not in {poss_aliases}"
-                )
-
-        # check HGNC release logging was correctly carried out
-        post_run_hgnc_release_links = GeneHgncRelease.objects.all()
-        errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 2)
-        for i in range(len(post_run_hgnc_release_links)):
-            errors += value_check_wrapper(post_run_hgnc_release_links[i].hgnc_release,
-                                          "linked release",
-                                          self.hgnc_release)
-
-        post_run_history = GeneHgncReleaseHistory.objects.all()
-        for i in range(len(post_run_history)):
-            errors += len_check_wrapper(post_run_history[i].note,
-                                        "linked history",
-                                        note=History.gene_hgnc_release_new)
-
-        errors = "; ".join(errors)
-        assert not errors, errors
-
-class TestGetOrCreate_AllGenesExistAlready(TestCase):
-    """
-    CASE: All the genes in the HGNC file, already exist in the database
-    EXPECT: The gene entry isn't made, but it is linked to the new release
-    """
-
-    def setUp(self) -> None:
-        self.hgnc_release = HgncRelease.objects.create(hgnc_release="new_hgnc")
-        self.user = "test user"
-
-    def test_adding_identical_gene(self):
-        errors = []
-
-        approved_symbols = {"HGNC:10257": "ROR2", "HGNC:TEST": "TEST_SYMBOL"}
-        alias_symbols = {"HGNC:10257": None, "HGNC:TEST": "TEST, ALIAS"}
-
-        _add_new_genes_to_db(approved_symbols, alias_symbols, self.hgnc_release, self.user)
+        _add_new_genes_to_db(input, self.hgnc_release, self.user)
 
         post_run_genes = Gene.objects.all()
         errors += len_check_wrapper(post_run_genes, "number of post run genes", 2)

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_get_or_create_gene_from_db.py
@@ -22,7 +22,7 @@ class TestGetOrCreate_CreateNew(TestCase):
 
     def setUp(self) -> None:
         self.hgnc_release = HgncRelease.objects.create(hgnc_release="new_hgnc")
-        self.user = "test user"
+        self.user = "init_v1_user"
 
     def test_adding_new_gene(self):
         errors = []

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
@@ -1,11 +1,19 @@
 from django.test import TestCase
 
 from requests_app.management.commands.history import History
-from requests_app.management.commands._parse_transcript import _link_unchanged_genes_to_new_release
-from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
-    len_check_wrapper, value_check_wrapper
+from requests_app.management.commands._parse_transcript import (
+    _link_unchanged_genes_to_new_release,
 )
-from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
+from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
+    len_check_wrapper,
+    value_check_wrapper,
+)
+from requests_app.models import (
+    Gene,
+    HgncRelease,
+    GeneHgncRelease,
+    GeneHgncReleaseHistory,
+)
 
 
 class TestLinkMade_GeneUnchanged(TestCase):
@@ -14,15 +22,21 @@ class TestLinkMade_GeneUnchanged(TestCase):
     EXPECT: Gene database entries remain the same, but new links are generated to the
     new HGNC release.
     """
+
     def setUp(self) -> None:
         self.user = "test_user"
 
         self.new_hgnc_release = HgncRelease.objects.create(hgnc_release="version2")
 
-        self.gene_1 = Gene.objects.get_or_create(hgnc_id="1", gene_symbol="gene one", alias_symbols=None)
-        self.gene_2 = Gene.objects.get_or_create(hgnc_id="2", gene_symbol="gene two", alias_symbols=None)
-        self.gene_3 = Gene.objects.get_or_create(hgnc_id="3", gene_symbol="gene three", alias_symbols=None)
-
+        self.gene_1 = Gene.objects.get_or_create(
+            hgnc_id="1", gene_symbol="gene one", alias_symbols=None
+        )
+        self.gene_2 = Gene.objects.get_or_create(
+            hgnc_id="2", gene_symbol="gene two", alias_symbols=None
+        )
+        self.gene_3 = Gene.objects.get_or_create(
+            hgnc_id="3", gene_symbol="gene three", alias_symbols=None
+        )
 
     def test_multiple_genes_linked_to_new_release(self):
         """
@@ -34,7 +48,9 @@ class TestLinkMade_GeneUnchanged(TestCase):
 
         input_hgncs = ["1", "2", "3"]
 
-        _link_unchanged_genes_to_new_release(input_hgncs, self.new_hgnc_release, self.user)
+        _link_unchanged_genes_to_new_release(
+            input_hgncs, self.new_hgnc_release, self.user
+        )
 
         genes = Gene.objects.all()
         errors += len_check_wrapper(genes, "number of genes", 3)
@@ -48,18 +64,25 @@ class TestLinkMade_GeneUnchanged(TestCase):
 
         # check HGNC release logging was correctly carried out
         post_run_hgnc_release_links = GeneHgncRelease.objects.all()
-        errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 3)
+        errors += len_check_wrapper(
+            post_run_hgnc_release_links, "number of release links", 3
+        )
 
         for i in range(len(post_run_hgnc_release_links)):
-            errors += value_check_wrapper(post_run_hgnc_release_links[i].hgnc_release,
-                                          "linked release", self.new_hgnc_release)
+            errors += value_check_wrapper(
+                post_run_hgnc_release_links[i].hgnc_release,
+                "linked release",
+                self.new_hgnc_release,
+            )
 
         post_run_history = GeneHgncReleaseHistory.objects.all()
         errors += len_check_wrapper(post_run_history, "history objects", 3)
         for i in range(len(post_run_history)):
-            errors += value_check_wrapper(post_run_history[i].note,
-                                        "linked history",
-                                        History.gene_hgnc_release_present())
+            errors += value_check_wrapper(
+                post_run_history[i].note,
+                "linked history",
+                History.gene_hgnc_release_present(),
+            )
 
         errors = "; ".join(errors)
         assert not errors, errors
@@ -71,15 +94,19 @@ class TestLinkAlreadyExists(TestCase):
     release.
     EXPECT: Gene-HGNC link remains the same, and no new history information is added.
     """
+
     def setUp(self) -> None:
         self.user = "test_user"
 
         self.new_hgnc_release = HgncRelease.objects.create(hgnc_release="version2")
 
-        self.gene_1 = Gene.objects.create(hgnc_id="1", gene_symbol="gene one", alias_symbols=None)
+        self.gene_1 = Gene.objects.create(
+            hgnc_id="1", gene_symbol="gene one", alias_symbols=None
+        )
 
-        self.link = GeneHgncRelease.objects.create(gene=self.gene_1,
-                                                          hgnc_release=self.new_hgnc_release)
+        self.link = GeneHgncRelease.objects.create(
+            gene=self.gene_1, hgnc_release=self.new_hgnc_release
+        )
 
     def test_no_history_if_gene_already_in_hgnc(self):
         """
@@ -91,21 +118,29 @@ class TestLinkAlreadyExists(TestCase):
 
         input_hgncs = ["1"]
 
-        _link_unchanged_genes_to_new_release(input_hgncs, self.new_hgnc_release, self.user)
+        _link_unchanged_genes_to_new_release(
+            input_hgncs, self.new_hgnc_release, self.user
+        )
 
         genes = Gene.objects.all()
         errors += len_check_wrapper(genes, "number of genes", 1)
 
         # check HGNC release link exists
         post_run_hgnc_release_links = GeneHgncRelease.objects.all()
-        errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 1)
-        errors += value_check_wrapper(post_run_hgnc_release_links[0].gene, "gene", self.gene_1)
-        errors += value_check_wrapper(post_run_hgnc_release_links[0].hgnc_release, "release", self.new_hgnc_release)
+        errors += len_check_wrapper(
+            post_run_hgnc_release_links, "number of release links", 1
+        )
+        errors += value_check_wrapper(
+            post_run_hgnc_release_links[0].gene, "gene", self.gene_1
+        )
+        errors += value_check_wrapper(
+            post_run_hgnc_release_links[0].hgnc_release,
+            "release",
+            self.new_hgnc_release,
+        )
 
         post_run_history = GeneHgncReleaseHistory.objects.all()
         errors += len_check_wrapper(post_run_history, "history objects", 0)
 
         errors = "; ".join(errors)
         assert not errors, errors
-
-

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
@@ -55,10 +55,11 @@ class TestLinkUnchanged(TestCase):
                                           "linked release", self.new_hgnc_release)
 
         post_run_history = GeneHgncReleaseHistory.objects.all()
+        errors += len_check_wrapper(post_run_history, "history objects", 3)
         for i in range(len(post_run_history)):
-            errors += len_check_wrapper(post_run_history[i].note,
+            errors += value_check_wrapper(post_run_history[i].note,
                                         "linked history",
-                                        note=History.gene_hgnc_release_unchanged)
+                                        History.gene_hgnc_release_present())
 
         errors = "; ".join(errors)
         assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+
+from requests_app.management.commands.history import History
+from requests_app.management.commands._parse_transcript import _link_unchanged_genes_to_new_release
+from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
+    len_check_wrapper, value_check_wrapper
+)
+from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
+
+
+class TestLinkUnchanged(TestCase):
+    """
+    CASE: Just emulates the case when genes are still the same in the new HGNC release
+    EXPECT: Gene database entries remain the same, but new links are generated to the
+    new HGNC release.
+    """
+    def setUp(self) -> None:
+        self.user = "test_user"
+
+        self.new_hgnc_release = HgncRelease.objects.create(hgnc_release="version2")
+
+        self.gene_1 = Gene.objects.get_or_create(hgnc_id="1", gene_symbol="gene one", alias_symbols=None)
+        self.gene_2 = Gene.objects.get_or_create(hgnc_id="2", gene_symbol="gene two", alias_symbols=None)
+        self.gene_3 = Gene.objects.get_or_create(hgnc_id="3", gene_symbol="gene three", alias_symbols=None)
+
+
+    def test_multiple_genes_linked_to_new_release(self):
+        """
+        CASE: Just emulates the case when genes are still the same in the new HGNC release
+        EXPECT: Gene database entries remain the same, but new links are generated to the
+        new HGNC release.
+        """
+        errors = []
+
+        input_hgncs = ["1", "2", "3"]
+
+        _link_unchanged_genes_to_new_release(input_hgncs, self.new_hgnc_release, self.user)
+
+        genes = Gene.objects.all()
+        errors += len_check_wrapper(genes, "number of genes", 3)
+
+        poss_symbols = ["gene one", "gene two", "gene three"]
+        for i in range(len(poss_symbols)):
+            if not genes[i].gene_symbol == poss_symbols[i]:
+                errors.append(
+                    f"Post run gene {genes[i].gene_symbol} not equal to {poss_symbols[i]}"
+                )
+
+        # check HGNC release logging was correctly carried out
+        post_run_hgnc_release_links = GeneHgncRelease.objects.all()
+        errors += len_check_wrapper(post_run_hgnc_release_links, "number of release links", 3)
+
+        for i in range(len(post_run_hgnc_release_links)):
+            errors += value_check_wrapper(post_run_hgnc_release_links[i].hgnc_release,
+                                          "linked release", self.new_hgnc_release)
+
+        post_run_history = GeneHgncReleaseHistory.objects.all()
+        for i in range(len(post_run_history)):
+            errors += len_check_wrapper(post_run_history[i].note,
+                                        "linked history",
+                                        note=History.gene_hgnc_release_unchanged)
+
+        errors = "; ".join(errors)
+        assert not errors, errors
+
+

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_link_unchanged_genes_to_new_release.py
@@ -24,7 +24,7 @@ class TestLinkMade_GeneUnchanged(TestCase):
     """
 
     def setUp(self) -> None:
-        self.user = "test_user"
+        self.user = "init_v1_user"
 
         self.new_hgnc_release = HgncRelease.objects.create(hgnc_release="version2")
 
@@ -96,7 +96,7 @@ class TestLinkAlreadyExists(TestCase):
     """
 
     def setUp(self) -> None:
-        self.user = "test_user"
+        self.user = "init_v1_user"
 
         self.new_hgnc_release = HgncRelease.objects.create(hgnc_release="version2")
 

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -1,0 +1,64 @@
+from django.test import TestCase
+
+from requests_app.management.commands.history import History
+from requests_app.management.commands._parse_transcript import _make_hgnc_gene_sets
+from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
+    len_check_wrapper, value_check_wrapper
+)
+from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
+
+
+
+class TestMakeHgncGeneSets_AllScenarios(TestCase):
+    """
+    CASE: Provide a mix of all expected types of case: 
+        - some genes are new and not in db
+        - some genes are already in db
+        - of genes in the db, some are unchanged, some have a changed alias, some have a changed 
+          symbol, some have both alias and symbol changes
+
+    EXPECT: The genes in the cases outlined above, are placed in the correct categories and returned.
+    """
+    def setUp(self) -> None:
+        # genes 1-3 below have changes in the new HGNC file
+        self.gene_one = Gene.objects.create(hgnc_id="HGNC:100", gene_symbol="ABC1", alias_symbols="Alias,One")
+        self.gene_two = Gene.objects.create(hgnc_id="HGNC:200", gene_symbol="DEF1", alias_symbols="Alias,Two")
+        self.gene_three = Gene.objects.create(hgnc_id="HGNC:300", gene_symbol="GHI1", alias_symbols="Alias,Three")
+        # gene_four will be entirely unchanged in the new HGNC file
+        self.gene_four = Gene.objects.create(hgnc_id="HGNC:400", gene_symbol="JKL1", alias_symbols="Alias,Four")
+        # gene_five isn't in the new HGNC file at all - it was added as part of an earlier release
+        self.gene_five = Gene.objects.create(hgnc_id="HGNC:500", gene_symbol="MNO1", alias_symbols="Alias,Five")
+
+
+    def test_four_categories(self):
+        hgnc_id_to_symbol = {"HGNC:100": "new_symbol", # HGNC:100 symbol change
+                             "HGNC:200": "DEF1",
+                             "HGNC:300": "not_GHI1", # HGNC:300 symbol and alias both changed
+                             "HGNC:400": "JKL1",
+                             "HGNC:600": "PQR1"} # HGNC:600 is new to this release, and not in the db
+        hgnc_id_to_alias = {"HGNC:100": ["Alias", "One"],
+                             "HGNC:200": ["new", "alias"], # HGNC:200 alias change
+                             "HGNC:300": ["not_Alias", "Three"], # HGNC:300 symbol and alias both changed
+                             "HGNC:400": ["Alias", "Four"],
+                             "HGNC:600": ["Alias", "Six"]} # HGNC:600 is new to this release, and not in the db
+
+        new_hgncs, hgnc_symbol_changed, hgnc_alias_changed, unchanged = \
+            _make_hgnc_gene_sets(hgnc_id_to_symbol, hgnc_id_to_alias)
+        
+        print("new hgncs")
+        print(new_hgncs)
+        print("hgnc_symbol_changed")
+        print(hgnc_symbol_changed)
+        print("hgnc_alias_changed")
+        print(hgnc_alias_changed)
+        print("unchanged")
+        print(unchanged)
+
+        self.assertDictEqual(new_hgncs[0], {"hgnc_id": "HGNC:600",
+                                                "symbol": "PQR1",
+                                                "alias": "Alias,Six"})
+        self.assertDictEqual(hgnc_symbol_changed, {"HGNC:100": "new_symbol",
+                                                       "HGNC:300": "not_GHI1"})
+        self.assertDictEqual(hgnc_alias_changed, {"HGNC:200": "new,alias",
+                                                      "HGNC:300": "not_Alias,Three"})
+        assert unchanged == ["HGNC:400"] #TODO: work out why 500 is getting put here for some reason

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -3,53 +3,82 @@ from django.test import TestCase
 from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import _make_hgnc_gene_sets
 from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
-    len_check_wrapper, value_check_wrapper
+    len_check_wrapper,
+    value_check_wrapper,
 )
-from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
-
+from requests_app.models import (
+    Gene,
+    HgncRelease,
+    GeneHgncRelease,
+    GeneHgncReleaseHistory,
+)
 
 
 class TestMakeHgncGeneSets_AllScenarios(TestCase):
     """
-    CASE: Provide a mix of all expected types of case: 
+    CASE: Provide a mix of all expected types of case:
         - some genes are new and not in db
         - some genes are already in db
-        - of genes in the db, some are unchanged, some have a changed alias, some have a changed 
+        - of genes in the db, some are unchanged, some have a changed alias, some have a changed
           symbol, some have both alias and symbol changes
 
     EXPECT: The genes in the cases outlined above, are placed in the correct categories and returned.
     """
+
     def setUp(self) -> None:
         # genes 1-3 below have changes in the new HGNC file
-        self.gene_one = Gene.objects.create(hgnc_id="HGNC:100", gene_symbol="ABC1", alias_symbols="Alias,One")
-        self.gene_two = Gene.objects.create(hgnc_id="HGNC:200", gene_symbol="DEF1", alias_symbols="Alias,Two")
-        self.gene_three = Gene.objects.create(hgnc_id="HGNC:300", gene_symbol="GHI1", alias_symbols="Alias,Three")
+        self.gene_one = Gene.objects.create(
+            hgnc_id="HGNC:100", gene_symbol="ABC1", alias_symbols="Alias,One"
+        )
+        self.gene_two = Gene.objects.create(
+            hgnc_id="HGNC:200", gene_symbol="DEF1", alias_symbols="Alias,Two"
+        )
+        self.gene_three = Gene.objects.create(
+            hgnc_id="HGNC:300", gene_symbol="GHI1", alias_symbols="Alias,Three"
+        )
         # gene_four will be entirely unchanged in the new HGNC file
-        self.gene_four = Gene.objects.create(hgnc_id="HGNC:400", gene_symbol="JKL1", alias_symbols="Alias,Four")
+        self.gene_four = Gene.objects.create(
+            hgnc_id="HGNC:400", gene_symbol="JKL1", alias_symbols="Alias,Four"
+        )
         # gene_five isn't in the new HGNC file at all - it was added as part of an earlier release
-        self.gene_five = Gene.objects.create(hgnc_id="HGNC:500", gene_symbol="MNO1", alias_symbols="Alias,Five")
-
+        self.gene_five = Gene.objects.create(
+            hgnc_id="HGNC:500", gene_symbol="MNO1", alias_symbols="Alias,Five"
+        )
 
     def test_four_categories(self):
-        hgnc_id_to_symbol = {"HGNC:100": "new_symbol", # HGNC:100 symbol change
-                             "HGNC:200": "DEF1",
-                             "HGNC:300": "not_GHI1", # HGNC:300 symbol and alias both changed
-                             "HGNC:400": "JKL1",
-                             "HGNC:600": "PQR1"} # HGNC:600 is new to this release, and not in the db
-        hgnc_id_to_alias = {"HGNC:100": ["Alias", "One"],
-                             "HGNC:200": ["new", "alias"], # HGNC:200 alias change
-                             "HGNC:300": ["not_Alias", "Three"], # HGNC:300 symbol and alias both changed
-                             "HGNC:400": ["Alias", "Four"],
-                             "HGNC:600": ["Alias", "Six"]} # HGNC:600 is new to this release, and not in the db
+        hgnc_id_to_symbol = {
+            "HGNC:100": "new_symbol",  # HGNC:100 symbol change
+            "HGNC:200": "DEF1",
+            "HGNC:300": "not_GHI1",  # HGNC:300 symbol and alias both changed
+            "HGNC:400": "JKL1",
+            "HGNC:600": "PQR1",
+        }  # HGNC:600 is new to this release, and not in the db
+        hgnc_id_to_alias = {
+            "HGNC:100": ["Alias", "One"],
+            "HGNC:200": ["new", "alias"],  # HGNC:200 alias change
+            "HGNC:300": [
+                "not_Alias",
+                "Three",
+            ],  # HGNC:300 symbol and alias both changed
+            "HGNC:400": ["Alias", "Four"],
+            "HGNC:600": ["Alias", "Six"],
+        }  # HGNC:600 is new to this release, and not in the db
 
-        new_hgncs, hgnc_symbol_changed, hgnc_alias_changed, unchanged = \
-            _make_hgnc_gene_sets(hgnc_id_to_symbol, hgnc_id_to_alias)
+        (
+            new_hgncs,
+            hgnc_symbol_changed,
+            hgnc_alias_changed,
+            unchanged,
+        ) = _make_hgnc_gene_sets(hgnc_id_to_symbol, hgnc_id_to_alias)
 
-        self.assertDictEqual(new_hgncs[0], {"hgnc_id": "HGNC:600",
-                                                "symbol": "PQR1",
-                                                "alias": "Alias,Six"})
-        self.assertDictEqual(hgnc_symbol_changed, {"HGNC:100": "new_symbol",
-                                                       "HGNC:300": "not_GHI1"})
-        self.assertDictEqual(hgnc_alias_changed, {"HGNC:200": "new,alias",
-                                                      "HGNC:300": "not_Alias,Three"})
+        self.assertDictEqual(
+            new_hgncs[0],
+            {"hgnc_id": "HGNC:600", "symbol": "PQR1", "alias": "Alias,Six"},
+        )
+        self.assertDictEqual(
+            hgnc_symbol_changed, {"HGNC:100": "new_symbol", "HGNC:300": "not_GHI1"}
+        )
+        self.assertDictEqual(
+            hgnc_alias_changed, {"HGNC:200": "new,alias", "HGNC:300": "not_Alias,Three"}
+        )
         assert unchanged == ["HGNC:400"]

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -80,10 +80,16 @@ class TestMakeHgncGeneSets_AllScenarios(TestCase):
             {"hgnc_id": "HGNC:600", "symbol": "PQR1", "alias": "Alias,Six"},
         )
         self.assertDictEqual(
-            hgnc_symbol_changed, {"HGNC:100": "new_symbol", "HGNC:300": "not_GHI1"}
+            hgnc_symbol_changed["HGNC:100"], {"new": "new_symbol", "old": "ABC1"}
         )
         self.assertDictEqual(
-            hgnc_alias_changed, {"HGNC:200": None, "HGNC:300": "not_Alias,Three"}
+            hgnc_symbol_changed["HGNC:300"], {"new": "not_GHI1", "old": "GHI1"}
+        )
+        self.assertDictEqual(
+            hgnc_alias_changed["HGNC:200"], {"new": None, "old": "Alias,Two"}
+        )
+        self.assertDictEqual(
+            hgnc_alias_changed["HGNC:300"], {"new": "not_Alias,Three", "old": "Alias,Three"}
         )
         assert unchanged == ["HGNC:400"]
 

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+import numpy as np
 
 from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import _make_hgnc_gene_sets
@@ -55,7 +56,7 @@ class TestMakeHgncGeneSets_AllScenarios(TestCase):
         }  # HGNC:600 is new to this release, and not in the db
         hgnc_id_to_alias = {
             "HGNC:100": ["Alias", "One"],
-            "HGNC:200": ["new", "alias"],  # HGNC:200 alias change
+            "HGNC:200": [np.nan],  # HGNC:200 alias change
             "HGNC:300": [
                 "not_Alias",
                 "Three",
@@ -79,6 +80,6 @@ class TestMakeHgncGeneSets_AllScenarios(TestCase):
             hgnc_symbol_changed, {"HGNC:100": "new_symbol", "HGNC:300": "not_GHI1"}
         )
         self.assertDictEqual(
-            hgnc_alias_changed, {"HGNC:200": "new,alias", "HGNC:300": "not_Alias,Three"}
+            hgnc_alias_changed, {"HGNC:200": None, "HGNC:300": "not_Alias,Three"}
         )
         assert unchanged == ["HGNC:400"]

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -89,7 +89,8 @@ class TestMakeHgncGeneSets_AllScenarios(TestCase):
             hgnc_alias_changed["HGNC:200"], {"new": None, "old": "Alias,Two"}
         )
         self.assertDictEqual(
-            hgnc_alias_changed["HGNC:300"], {"new": "not_Alias,Three", "old": "Alias,Three"}
+            hgnc_alias_changed["HGNC:300"],
+            {"new": "not_Alias,Three", "old": "Alias,Three"},
         )
         assert unchanged == ["HGNC:400"]
 

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -44,15 +44,6 @@ class TestMakeHgncGeneSets_AllScenarios(TestCase):
 
         new_hgncs, hgnc_symbol_changed, hgnc_alias_changed, unchanged = \
             _make_hgnc_gene_sets(hgnc_id_to_symbol, hgnc_id_to_alias)
-        
-        print("new hgncs")
-        print(new_hgncs)
-        print("hgnc_symbol_changed")
-        print(hgnc_symbol_changed)
-        print("hgnc_alias_changed")
-        print(hgnc_alias_changed)
-        print("unchanged")
-        print(unchanged)
 
         self.assertDictEqual(new_hgncs[0], {"hgnc_id": "HGNC:600",
                                                 "symbol": "PQR1",
@@ -61,4 +52,4 @@ class TestMakeHgncGeneSets_AllScenarios(TestCase):
                                                        "HGNC:300": "not_GHI1"})
         self.assertDictEqual(hgnc_alias_changed, {"HGNC:200": "new,alias",
                                                       "HGNC:300": "not_Alias,Three"})
-        assert unchanged == ["HGNC:400"] #TODO: work out why 500 is getting put here for some reason
+        assert unchanged == ["HGNC:400"]

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -2,7 +2,10 @@ from django.test import TestCase
 import numpy as np
 
 from requests_app.management.commands.history import History
-from requests_app.management.commands._parse_transcript import _make_hgnc_gene_sets, _resolve_alias
+from requests_app.management.commands._parse_transcript import (
+    _make_hgnc_gene_sets,
+    _resolve_alias,
+)
 from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
     len_check_wrapper,
     value_check_wrapper,
@@ -90,6 +93,7 @@ class TestResolveAlias(TestCase):
     Check that common alias name scenarios are correctly parsed into
     either None or a joined string
     """
+
     def test_resolve_alias(self):
         assert _resolve_alias(None) == None
         assert _resolve_alias([None]) == None

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_make_hgnc_gene_sets.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 import numpy as np
 
 from requests_app.management.commands.history import History
-from requests_app.management.commands._parse_transcript import _make_hgnc_gene_sets
+from requests_app.management.commands._parse_transcript import _make_hgnc_gene_sets, _resolve_alias
 from tests.tests_requests_app.test_management.test_commands.test_insert_ci.test_insert_test_directory_data import (
     len_check_wrapper,
     value_check_wrapper,
@@ -83,3 +83,16 @@ class TestMakeHgncGeneSets_AllScenarios(TestCase):
             hgnc_alias_changed, {"HGNC:200": None, "HGNC:300": "not_Alias,Three"}
         )
         assert unchanged == ["HGNC:400"]
+
+
+class TestResolveAlias(TestCase):
+    """
+    Check that common alias name scenarios are correctly parsed into
+    either None or a joined string
+    """
+    def test_resolve_alias(self):
+        assert _resolve_alias(None) == None
+        assert _resolve_alias([None]) == None
+        assert _resolve_alias([np.nan]) == None
+        assert _resolve_alias(["Test", "One"]) == "Test,One"
+        assert _resolve_alias(["One", "Test"]) == "One,Test"

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
@@ -132,7 +132,7 @@ class TestUpdateExistingAliasSymbol(TestCase):
         """
         A gene is unchanged
         """
-        test_aliases = {"14163": ["DKFZP761D0211", "FLJ32603"]}
+        test_aliases = {"14163": "DKFZP761D0211,FLJ32603"}
         _update_existing_gene_metadata_aliases_in_db(test_aliases, self.hgnc_release,
                                                      self.user)
 
@@ -148,8 +148,7 @@ class TestUpdateExistingAliasSymbol(TestCase):
         Test case: the alias name has changed for a gene, since last update
         No change in approved name
         """
-        made_up_aliases = ["alias1", "alias2"]
-        test_hgnc_aliases = {"14163": made_up_aliases}
+        test_hgnc_aliases = {"14163": "alias1,alias2"}
 
         _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases, self.hgnc_release,
                                                      self.user)
@@ -157,37 +156,4 @@ class TestUpdateExistingAliasSymbol(TestCase):
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db = Gene.objects.filter(hgnc_id="14163")
         assert len(gene_db) == 1
-        assert gene_db[0].alias_symbols == ",".join(made_up_aliases)
-
-    def test_alias_now_numpy_na(self):
-        """
-        Test case: the alias name has changed for a gene, since last update
-        It is now numpy 'na' data
-        Expected: the alias is skipped and the old one is kept
-        """
-        made_up_aliases = [np.nan]
-        test_hgnc_aliases = {"14163": made_up_aliases}
-
-        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases, self.hgnc_release,
-                                                     self.user)
-
-        # expect the entry for 14163 in the Gene test datatable to NOT update
-        gene_db = Gene.objects.filter(hgnc_id="14163")
-        assert len(gene_db) == 1
-        assert gene_db[0].alias_symbols == self.FAM234A.alias_symbols
-
-    def test_alias_list_empty(self):
-        """
-        Test case: the alias name has changed for a gene, since last update
-        It is now an empty list
-        Expected: the alias is skipped and the old one is kept
-        """
-        made_up_aliases = []
-        test_hgnc_aliases = {"14163": made_up_aliases}
-
-        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases, self.hgnc_release,
-                                                     self.user)
-        # expect the entry for 14163 in the Gene test datatable to NOT update
-        gene_db = Gene.objects.filter(hgnc_id="14163")
-        assert len(gene_db) == 1
-        assert gene_db[0].alias_symbols == self.FAM234A.alias_symbols
+        assert gene_db[0].alias_symbols == "alias1,alias2"

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
@@ -1,7 +1,12 @@
 from django.test import TestCase
 import numpy as np
 
-from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
+from requests_app.models import (
+    Gene,
+    HgncRelease,
+    GeneHgncRelease,
+    GeneHgncReleaseHistory,
+)
 
 from requests_app.management.commands.history import History
 from requests_app.management.commands._parse_transcript import (
@@ -12,6 +17,7 @@ from tests.tests_requests_app.test_management.test_commands.test_insert_panel.te
     len_check_wrapper,
     value_check_wrapper,
 )
+
 
 class TestUpdateExistingGeneSymbol(TestCase):
     """
@@ -40,9 +46,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
             hgnc_id="50", gene_symbol=None, alias_symbols=None
         )
 
-        self.hgnc_release = HgncRelease.objects.create(
-            hgnc_release="hgnc_v1"
-        )
+        self.hgnc_release = HgncRelease.objects.create(hgnc_release="hgnc_v1")
 
         self.user = "test_user"
 
@@ -54,13 +58,16 @@ class TestUpdateExistingGeneSymbol(TestCase):
 
         made_up_approved_name = "FAM234A_test"
         test_hgnc_approved = {"14163": made_up_approved_name}
-        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved, self.hgnc_release,
-                                                    self.user)
+        _update_existing_gene_metadata_symbol_in_db(
+            test_hgnc_approved, self.hgnc_release, self.user
+        )
 
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db = Gene.objects.filter(hgnc_id="14163")
         err += len_check_wrapper(gene_db, "gene objects matching 14163", 1)
-        err += value_check_wrapper(gene_db[0].gene_symbol, "gene symbol", made_up_approved_name)
+        err += value_check_wrapper(
+            gene_db[0].gene_symbol, "gene symbol", made_up_approved_name
+        )
 
         # check that the entry has been linked to a HgncRelease
         gene_release = GeneHgncRelease.objects.all()
@@ -70,9 +77,14 @@ class TestUpdateExistingGeneSymbol(TestCase):
         # and there's a HgncRelease history entry with the 'symbol change' message
         history = GeneHgncReleaseHistory.objects.all()
         err += len_check_wrapper(history, "history entries", 1)
-        err += value_check_wrapper(history[0].gene_hgnc_release, "Gene-HGNC link", gene_release[0])
-        err += value_check_wrapper(history[0].note, "history note",
-                                   History.gene_hgnc_release_approved_symbol_change())
+        err += value_check_wrapper(
+            history[0].gene_hgnc_release, "Gene-HGNC link", gene_release[0]
+        )
+        err += value_check_wrapper(
+            history[0].note,
+            "history note",
+            History.gene_hgnc_release_approved_symbol_change(),
+        )
 
         errors = "; ".join(err)
         assert not errors, errors
@@ -89,38 +101,58 @@ class TestUpdateExistingGeneSymbol(TestCase):
             "14163": made_up_approved_name,
             "12713": made_up_approved_name_two,
         }
-        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved, self.hgnc_release,
-                                                    self.user)
+        _update_existing_gene_metadata_symbol_in_db(
+            test_hgnc_approved, self.hgnc_release, self.user
+        )
 
         err = []
 
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db_one = Gene.objects.filter(hgnc_id="14163")
         err += len_check_wrapper(gene_db_one, "genes matching 14163", 1)
-        err += value_check_wrapper(gene_db_one[0].gene_symbol, "gene symbol", made_up_approved_name)
+        err += value_check_wrapper(
+            gene_db_one[0].gene_symbol, "gene symbol", made_up_approved_name
+        )
 
         gene_db_two = Gene.objects.filter(hgnc_id="12713")
         err += len_check_wrapper(gene_db_two, "genes matching 12713", 1)
-        err += value_check_wrapper(gene_db_two[0].gene_symbol, "gene symbol", made_up_approved_name_two)
+        err += value_check_wrapper(
+            gene_db_two[0].gene_symbol, "gene symbol", made_up_approved_name_two
+        )
 
         # check that the two gene entries have been linked to a HgncRelease
         gene_release = GeneHgncRelease.objects.all()
         err += len_check_wrapper(gene_release, "Gene-HGNC links", 2)
-        err += value_check_wrapper(gene_release[0].gene, "gene in the link", gene_db_one[0])
-        err += value_check_wrapper(gene_release[1].gene, "gene in the link", gene_db_two[0])
+        err += value_check_wrapper(
+            gene_release[0].gene, "gene in the link", gene_db_one[0]
+        )
+        err += value_check_wrapper(
+            gene_release[1].gene, "gene in the link", gene_db_two[0]
+        )
 
         # and there's a HgncRelease history entry with the 'symbol change' message
         history = GeneHgncReleaseHistory.objects.all()
         err += len_check_wrapper(history, "history", 2)
-        err += value_check_wrapper(history[0].gene_hgnc_release, "Gene-HGNC link", gene_release[0])
-        err += value_check_wrapper(history[0].note, "history note",
-                                   History.gene_hgnc_release_approved_symbol_change())
-        err += value_check_wrapper(history[1].gene_hgnc_release, "Gene-HGNC link", gene_release[1])
-        err += value_check_wrapper(history[1].note, "history note",
-                                   History.gene_hgnc_release_approved_symbol_change())
+        err += value_check_wrapper(
+            history[0].gene_hgnc_release, "Gene-HGNC link", gene_release[0]
+        )
+        err += value_check_wrapper(
+            history[0].note,
+            "history note",
+            History.gene_hgnc_release_approved_symbol_change(),
+        )
+        err += value_check_wrapper(
+            history[1].gene_hgnc_release, "Gene-HGNC link", gene_release[1]
+        )
+        err += value_check_wrapper(
+            history[1].note,
+            "history note",
+            History.gene_hgnc_release_approved_symbol_change(),
+        )
 
         errors = "; ".join(err)
         assert not errors, errors
+
 
 class TestUpdateExistingAliasSymbol(TestCase):
     """
@@ -149,9 +181,7 @@ class TestUpdateExistingAliasSymbol(TestCase):
             hgnc_id="50", gene_symbol=None, alias_symbols=None
         )
 
-        self.hgnc_release = HgncRelease.objects.create(
-            hgnc_release="hgnc_v1"
-        )
+        self.hgnc_release = HgncRelease.objects.create(hgnc_release="hgnc_v1")
 
         self.user = "test_user"
 
@@ -162,15 +192,18 @@ class TestUpdateExistingAliasSymbol(TestCase):
         """
         test_hgnc_aliases = {"14163": "alias1,alias2"}
 
-        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases, self.hgnc_release,
-                                                     self.user)
+        _update_existing_gene_metadata_aliases_in_db(
+            test_hgnc_aliases, self.hgnc_release, self.user
+        )
 
         err = []
 
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db = Gene.objects.filter(hgnc_id="14163")
         err += len_check_wrapper(gene_db, "genes", 1)
-        err += value_check_wrapper(gene_db[0].alias_symbols, "alias symbol", "alias1,alias2")
+        err += value_check_wrapper(
+            gene_db[0].alias_symbols, "alias symbol", "alias1,alias2"
+        )
 
         # check that the entry has been linked to a HgncRelease
         gene_release = GeneHgncRelease.objects.all()
@@ -180,9 +213,14 @@ class TestUpdateExistingAliasSymbol(TestCase):
         # and there's a HgncRelease history entry with the 'symbol change' message
         history = GeneHgncReleaseHistory.objects.all()
         err += len_check_wrapper(history, "history entries", 1)
-        err += value_check_wrapper(history[0].gene_hgnc_release, "Gene-HGNC link", gene_release[0])
-        err += value_check_wrapper(history[0].note, "history note",
-                                   History.gene_hgnc_release_alias_symbol_change())
+        err += value_check_wrapper(
+            history[0].gene_hgnc_release, "Gene-HGNC link", gene_release[0]
+        )
+        err += value_check_wrapper(
+            history[0].note,
+            "history note",
+            History.gene_hgnc_release_alias_symbol_change(),
+        )
 
         errors = "; ".join(err)
         assert not errors, errors

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
@@ -66,9 +66,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db = Gene.objects.filter(hgnc_id="14163")
         err += len_check_wrapper(gene_db, "gene objects matching 14163", 1)
-        err += value_check_wrapper(
-            gene_db[0].gene_symbol, "gene symbol", new_name
-        )
+        err += value_check_wrapper(gene_db[0].gene_symbol, "gene symbol", new_name)
 
         # check that the entry has been linked to a HgncRelease
         gene_release = GeneHgncRelease.objects.all()
@@ -102,7 +100,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
 
         test_hgnc_approved = {
             "14163": {"new": new_name, "old": old_name},
-            "12713": {"new": new_name_two, "old": old_name_two}
+            "12713": {"new": new_name_two, "old": old_name_two},
         }
         _update_existing_gene_metadata_symbol_in_db(
             test_hgnc_approved, self.hgnc_release, self.user
@@ -113,9 +111,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db_one = Gene.objects.filter(hgnc_id="14163")
         err += len_check_wrapper(gene_db_one, "genes matching 14163", 1)
-        err += value_check_wrapper(
-            gene_db_one[0].gene_symbol, "gene symbol", new_name
-        )
+        err += value_check_wrapper(gene_db_one[0].gene_symbol, "gene symbol", new_name)
 
         gene_db_two = Gene.objects.filter(hgnc_id="12713")
         err += len_check_wrapper(gene_db_two, "genes matching 12713", 1)
@@ -150,7 +146,9 @@ class TestUpdateExistingGeneSymbol(TestCase):
         err += value_check_wrapper(
             history[1].note,
             "history note",
-            History.gene_hgnc_release_approved_symbol_change(old_name_two, new_name_two),
+            History.gene_hgnc_release_approved_symbol_change(
+                old_name_two, new_name_two
+            ),
         )
 
         errors = "; ".join(err)

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
@@ -56,8 +56,9 @@ class TestUpdateExistingGeneSymbol(TestCase):
         """
         err = []
 
-        made_up_approved_name = "FAM234A_test"
-        test_hgnc_approved = {"14163": made_up_approved_name}
+        new_name = "FAM234A_test"
+        old_name = "FAM234A"
+        test_hgnc_approved = {"14163": {"new": new_name, "old": old_name}}
         _update_existing_gene_metadata_symbol_in_db(
             test_hgnc_approved, self.hgnc_release, self.user
         )
@@ -66,7 +67,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
         gene_db = Gene.objects.filter(hgnc_id="14163")
         err += len_check_wrapper(gene_db, "gene objects matching 14163", 1)
         err += value_check_wrapper(
-            gene_db[0].gene_symbol, "gene symbol", made_up_approved_name
+            gene_db[0].gene_symbol, "gene symbol", new_name
         )
 
         # check that the entry has been linked to a HgncRelease
@@ -83,7 +84,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
         err += value_check_wrapper(
             history[0].note,
             "history note",
-            History.gene_hgnc_release_approved_symbol_change(),
+            History.gene_hgnc_release_approved_symbol_change(old_name, new_name),
         )
 
         errors = "; ".join(err)
@@ -94,12 +95,14 @@ class TestUpdateExistingGeneSymbol(TestCase):
         Test case: the approved name has changed for several genes, since last
         update
         """
-        made_up_approved_name = "FAM234A_test"
-        made_up_approved_name_two = "test_nonsense"
+        new_name = "FAM234A_test"
+        old_name = "test"
+        new_name_two = "test_nonsense"
+        old_name_two = "nonsense"
 
         test_hgnc_approved = {
-            "14163": made_up_approved_name,
-            "12713": made_up_approved_name_two,
+            "14163": {"new": new_name, "old": old_name},
+            "12713": {"new": new_name_two, "old": old_name_two}
         }
         _update_existing_gene_metadata_symbol_in_db(
             test_hgnc_approved, self.hgnc_release, self.user
@@ -111,13 +114,13 @@ class TestUpdateExistingGeneSymbol(TestCase):
         gene_db_one = Gene.objects.filter(hgnc_id="14163")
         err += len_check_wrapper(gene_db_one, "genes matching 14163", 1)
         err += value_check_wrapper(
-            gene_db_one[0].gene_symbol, "gene symbol", made_up_approved_name
+            gene_db_one[0].gene_symbol, "gene symbol", new_name
         )
 
         gene_db_two = Gene.objects.filter(hgnc_id="12713")
         err += len_check_wrapper(gene_db_two, "genes matching 12713", 1)
         err += value_check_wrapper(
-            gene_db_two[0].gene_symbol, "gene symbol", made_up_approved_name_two
+            gene_db_two[0].gene_symbol, "gene symbol", new_name_two
         )
 
         # check that the two gene entries have been linked to a HgncRelease
@@ -139,7 +142,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
         err += value_check_wrapper(
             history[0].note,
             "history note",
-            History.gene_hgnc_release_approved_symbol_change(),
+            History.gene_hgnc_release_approved_symbol_change(old_name, new_name),
         )
         err += value_check_wrapper(
             history[1].gene_hgnc_release, "Gene-HGNC link", gene_release[1]
@@ -147,7 +150,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
         err += value_check_wrapper(
             history[1].note,
             "history note",
-            History.gene_hgnc_release_approved_symbol_change(),
+            History.gene_hgnc_release_approved_symbol_change(old_name_two, new_name_two),
         )
 
         errors = "; ".join(err)
@@ -190,7 +193,9 @@ class TestUpdateExistingAliasSymbol(TestCase):
         Test case: the alias name has changed for a gene, since last update
         No change in approved name
         """
-        test_hgnc_aliases = {"14163": "alias1,alias2"}
+        old_alias = "alias1"
+        new_alias = "alias1,alias2"
+        test_hgnc_aliases = {"14163": {"new": new_alias, "old": old_alias}}
 
         _update_existing_gene_metadata_aliases_in_db(
             test_hgnc_aliases, self.hgnc_release, self.user
@@ -219,7 +224,7 @@ class TestUpdateExistingAliasSymbol(TestCase):
         err += value_check_wrapper(
             history[0].note,
             "history note",
-            History.gene_hgnc_release_alias_symbol_change(),
+            History.gene_hgnc_release_alias_symbol_change(old_alias, new_alias),
         )
 
         errors = "; ".join(err)

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 import numpy as np
 
-from requests_app.models import Gene
+from requests_app.models import Gene, HgncRelease, GeneHgncRelease, GeneHgncReleaseHistory
 
 from requests_app.management.commands._parse_transcript import (
     _update_existing_gene_metadata_symbol_in_db,
@@ -36,12 +36,19 @@ class TestUpdateExistingGeneSymbol(TestCase):
             hgnc_id="50", gene_symbol=None, alias_symbols=None
         )
 
+        self.hgnc_release = HgncRelease.objects.create(
+            hgnc_release="hgnc_v1"
+        )
+
+        self.user = "test_user"
+
     def test_no_changes(self):
         """
         A gene is unchanged
         """
         test_hgnc_approved = {"14163": "FAM234A"}
-        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved)
+        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved, self.hgnc_release,
+                                                    self.user)
 
         # check that the entry isn't changed from how it was at set-up
         gene_db = Gene.objects.filter(hgnc_id="14163")
@@ -55,7 +62,8 @@ class TestUpdateExistingGeneSymbol(TestCase):
         """
         made_up_approved_name = "FAM234A_test"
         test_hgnc_approved = {"14163": made_up_approved_name}
-        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved)
+        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved, self.hgnc_release,
+                                                    self.user)
 
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db = Gene.objects.filter(hgnc_id="14163")
@@ -74,7 +82,8 @@ class TestUpdateExistingGeneSymbol(TestCase):
             "14163": made_up_approved_name,
             "12713": made_up_approved_name_two,
         }
-        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved)
+        _update_existing_gene_metadata_symbol_in_db(test_hgnc_approved, self.hgnc_release,
+                                                    self.user)
 
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db = Gene.objects.filter(hgnc_id="14163")
@@ -113,12 +122,19 @@ class TestUpdateExistingAliasSymbol(TestCase):
             hgnc_id="50", gene_symbol=None, alias_symbols=None
         )
 
+        self.hgnc_release = HgncRelease.objects.create(
+            hgnc_release="hgnc_v1"
+        )
+
+        self.user = "test_user"
+
     def test_no_changes(self):
         """
         A gene is unchanged
         """
         test_aliases = {"14163": ["DKFZP761D0211", "FLJ32603"]}
-        _update_existing_gene_metadata_aliases_in_db(test_aliases)
+        _update_existing_gene_metadata_aliases_in_db(test_aliases, self.hgnc_release,
+                                                     self.user)
 
         # check that the entry isn't changed from how it was at set-up
         gene_db = Gene.objects.filter(hgnc_id="14163")
@@ -135,7 +151,8 @@ class TestUpdateExistingAliasSymbol(TestCase):
         made_up_aliases = ["alias1", "alias2"]
         test_hgnc_aliases = {"14163": made_up_aliases}
 
-        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases)
+        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases, self.hgnc_release,
+                                                     self.user)
 
         # check that the entry for 14163 in the Gene test datatable is updated
         gene_db = Gene.objects.filter(hgnc_id="14163")
@@ -151,7 +168,8 @@ class TestUpdateExistingAliasSymbol(TestCase):
         made_up_aliases = [np.nan]
         test_hgnc_aliases = {"14163": made_up_aliases}
 
-        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases)
+        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases, self.hgnc_release,
+                                                     self.user)
 
         # expect the entry for 14163 in the Gene test datatable to NOT update
         gene_db = Gene.objects.filter(hgnc_id="14163")
@@ -167,8 +185,8 @@ class TestUpdateExistingAliasSymbol(TestCase):
         made_up_aliases = []
         test_hgnc_aliases = {"14163": made_up_aliases}
 
-        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases)
-
+        _update_existing_gene_metadata_aliases_in_db(test_hgnc_aliases, self.hgnc_release,
+                                                     self.user)
         # expect the entry for 14163 in the Gene test datatable to NOT update
         gene_db = Gene.objects.filter(hgnc_id="14163")
         assert len(gene_db) == 1

--- a/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_parse_transcript/test_update_existing_gene_metadata_in_db.py
@@ -48,7 +48,7 @@ class TestUpdateExistingGeneSymbol(TestCase):
 
         self.hgnc_release = HgncRelease.objects.create(hgnc_release="hgnc_v1")
 
-        self.user = "test_user"
+        self.user = "init_v1_user"
 
     def test_approved_name_change(self):
         """
@@ -186,7 +186,7 @@ class TestUpdateExistingAliasSymbol(TestCase):
 
         self.hgnc_release = HgncRelease.objects.create(hgnc_release="hgnc_v1")
 
-        self.user = "test_user"
+        self.user = "init_v1_user"
 
     def test_alias_name_change(self):
         """


### PR DESCRIPTION
PR to close the following two tickets, and improve auditing in the database:
IN-334 Add HGNC release info to the Eris db (these get linked to affected Genes)
IN-335 Add GFF file release info to the Eris db (these get linked to affected Transcripts)

Changes included:
- Adding release-related user inputs for HGNC and GFF
- Added sanity checkers for releases to enforce correct format, and to stop old releases overwriting newer ones
- HGNC release versions are created in the db, and linked to any Genes that are created/modified by that release (e.g. if an alias symbol changes) or are present in that release
- GFF release versions are created in the db, and linked to any Transcripts that are created by that release, or are present in that release

Unit tests were amended to include these changes.
Unit tests are completing:
----------------------------------------------------------------------
Ran 99 tests in 2.659s

OK

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/47)
<!-- Reviewable:end -->
