### PR TITLE
Bugfixes/backwards compatibility enforced for type hints

### DIFF
--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -5,6 +5,7 @@
 import os
 
 from django.db import transaction
+from typing import Dict, List, Tuple, Union
 
 from .utils import sortable_version, normalize_version
 from .history import History
@@ -28,11 +29,11 @@ from requests_app.models import (
 )
 
 
-def _backward_deactivate(indications: list[dict], user: str) -> None:
+def _backward_deactivate(indications: List[Dict], user: str) -> None:
     """
     This function flag any clinical indication that doesn't exist in TestDirectory
 
-    :params: indications [list]: list of clinical indication from TD
+    :params: indications [List]: List of clinical indication from TD
     :params: user [str]: user who is importing the TD
     """
     r_codes = set([indication["code"] for indication in indications])
@@ -194,7 +195,7 @@ def provisionally_link_clinical_indication_to_superpanel(
     return ci_superpanel_instance
 
 
-def _get_td_version(filename: str) -> str | None:
+def _get_td_version(filename: str) -> Union[str, None]:
     """
     Get TD version from filename.
     convert "rare-and-inherited-disease-national-genomic-test-directory-v4.xlsx" into "4"
@@ -244,7 +245,7 @@ def _check_td_version_valid(
             )
 
 
-def _retrieve_panel_from_pa_id(ci_code: str, pa_id: str) -> Panel | None:
+def _retrieve_panel_from_pa_id(ci_code: str, pa_id: str) -> Union[Panel, None]:
     """
     Retrieve a single Panel record based on PA panel id.
     We order multiple Panel records by version and select the highest,
@@ -265,7 +266,7 @@ def _retrieve_panel_from_pa_id(ci_code: str, pa_id: str) -> Panel | None:
     return panel_instance
 
 
-def _retrieve_superpanel_from_pa_id(ci_code: str, pa_id: str) -> SuperPanel | None:
+def _retrieve_superpanel_from_pa_id(ci_code: str, pa_id: str) -> Union[SuperPanel, None]:
     """
     Retrieve a single SuperPanel record based on PA panel id.
     We order multiple SuperPanel records by version and select the highest,
@@ -287,7 +288,7 @@ def _retrieve_superpanel_from_pa_id(ci_code: str, pa_id: str) -> SuperPanel | No
 
 
 def _retrieve_unknown_metadata_records() -> (
-    tuple[Confidence, ModeOfInheritance, ModeOfPathogenicity, Penetrance]
+    Tuple[Confidence, ModeOfInheritance, ModeOfPathogenicity, Penetrance]
 ):
     """
     Retrieve additional metadata records for PanelGene records
@@ -311,9 +312,9 @@ def _retrieve_unknown_metadata_records() -> (
 
 
 def _make_panels_from_hgncs(
-    json_data: dict,
+    json_data: Dict,
     ci: ClinicalIndication,
-    hgnc_list: list,
+    hgnc_list: List,
 ) -> None:
     """
     Make Panel records from a list of HGNC ids.
@@ -738,7 +739,7 @@ def _attempt_ci_panel_creation(
     td_version: str,
     td_source: str,
     config_source: str,
-) -> tuple[ClinicalIndicationPanel, bool]:
+) -> Tuple[ClinicalIndicationPanel, bool]:
     """
     Gets-or-creates a ClinicalIndicationPanel entry.
     If the entry is new, it will log history too.
@@ -784,7 +785,7 @@ def _attempt_ci_superpanel_creation(
     td_version: str,
     td_source: str,
     config_source: str,
-) -> tuple[ClinicalIndicationSuperPanel, bool]:
+) -> Tuple[ClinicalIndicationSuperPanel, bool]:
     """
     Gets-or-creates a ClinicalIndicationSuperPanel entry.
     If the entry is new, it will log history too.
@@ -825,7 +826,7 @@ def _attempt_ci_superpanel_creation(
 
 
 def _flag_panels_removed_from_test_directory(
-    ci_instance: ClinicalIndication, panels: list, td_source: str
+    ci_instance: ClinicalIndication, panels: List, td_source: str
 ) -> None:
     """
     For a clinical indication, finds any pre-existing links to Panels and
@@ -864,7 +865,7 @@ def _flag_panels_removed_from_test_directory(
 
 
 def _flag_superpanels_removed_from_test_directory(
-    ci_instance: ClinicalIndication, panels: list, td_source: str
+    ci_instance: ClinicalIndication, panels: List, td_source: str
 ) -> None:
     """
     For a clinical indication, finds any pre-existing links to SuperPanels and
@@ -930,7 +931,7 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
     latest_td_version_in_db = _fetch_latest_td_version()
     _check_td_version_valid(td_version, latest_td_version_in_db, force)
 
-    all_indication: list[dict] = json_data["indications"]
+    all_indication: List[Dict] = json_data["indications"]
 
     for indication in all_indication:
         r_code: str = indication["code"].strip()
@@ -961,7 +962,7 @@ def insert_test_directory_data(json_data: dict, force: bool = False) -> None:
                 )
 
         # link each CI record to the appropriate Panel records
-        hgnc_list: list[str] = []
+        hgnc_list: List[str] = []
 
         # attaching Panels to CI
         if indication["panels"]:

--- a/web/utils/utils.py
+++ b/web/utils/utils.py
@@ -1,7 +1,7 @@
 """
 External python modules or scripts relavant to the web app
 """
-
+from typing import List
 
 class Genepanel:
     """
@@ -15,7 +15,7 @@ class Genepanel:
         ci_name: str,
         panel_name: str,
         panel_version: str,
-        hgncs: list[str],
+        hgncs: List[str],
     ) -> None:
         self.r_code = r_code
         self.ci_name = ci_name

--- a/web/views.py
+++ b/web/views.py
@@ -1,10 +1,12 @@
+import json
+import collections
+import datetime as dt
+import dxpy as dx
 import secrets
 import string
-import collections
-import json
+
 from itertools import chain
-import dxpy as dx
-import datetime as dt
+from typing import List, Dict
 
 from django.shortcuts import render, redirect
 from django.db.models import QuerySet, Q
@@ -41,12 +43,12 @@ def index(request):
     """
 
     # fetch all clinical indications
-    all_ci: list[ClinicalIndication] = ClinicalIndication.objects.order_by(
+    all_ci: List[ClinicalIndication] = ClinicalIndication.objects.order_by(
         "r_code"
     ).all()
 
     # fetch all panels
-    all_panels: list[dict] = Panel.objects.order_by("panel_name").all()
+    all_panels: List[Dict] = Panel.objects.order_by("panel_name").all()
 
     # normalize panel version
     for panel in all_panels:
@@ -130,7 +132,7 @@ def panel(request, panel_id: int):
     agg_history = list(chain(ci_test_method_history, ci_panels_history))
 
     # fetch genes associated with panel
-    pgs: QuerySet[dict] = (
+    pgs: QuerySet[Dict] = (
         PanelGene.objects.filter(panel_id=panel_id)
         .values(
             "gene_id",
@@ -251,7 +253,7 @@ def clinical_indication(request, ci_id: int):
     agg_history = list(chain(ci_test_method_history, ci_panels_history))
 
     # fetch panel-gene
-    panel_genes: QuerySet[dict] = (
+    panel_genes: QuerySet[Dict] = (
         PanelGene.objects.filter(
             panel_id__in=[p.id for p in panels if p.id in active_panel_ids]
         )
@@ -266,7 +268,7 @@ def clinical_indication(request, ci_id: int):
     )
 
     # prepare panel-gene dict
-    panel_genes_dict: dict[str, list] = collections.defaultdict(list)
+    panel_genes_dict: Dict[str, List] = collections.defaultdict(list)
 
     for pg in panel_genes:
         # there can be multiple history associated with a panel-gene id
@@ -464,7 +466,7 @@ def add_ci_panel(request, ci_id: int):
     """
 
     # find all panel linked to this ci
-    linked_panels: list[int] = [
+    linked_panels: List[int] = [
         cip.panel_id
         for cip in ClinicalIndicationPanel.objects.filter(
             clinical_indication_id=ci_id, current=True
@@ -482,7 +484,7 @@ def add_ci_panel(request, ci_id: int):
 
     if request.method == "GET":
         # active ci-panel links
-        linked_panels: list[int] = [
+        linked_panels: List[int] = [
             cip.panel_id
             for cip in ClinicalIndicationPanel.objects.filter(
                 clinical_indication_id=ci_id, current=True
@@ -490,7 +492,7 @@ def add_ci_panel(request, ci_id: int):
         ]
 
         # fetch any pending ci-panel links
-        pending_ci_panels: list[int] = [
+        pending_ci_panels: List[int] = [
             cip.panel_id
             for cip in ClinicalIndicationPanel.objects.filter(
                 clinical_indication_id=ci_id, pending=True
@@ -560,7 +562,7 @@ def add_ci_panel(request, ci_id: int):
                     user="online",
                 )
 
-        linked_panels: list[int] = [
+        linked_panels: List[int] = [
             cip.panel_id
             for cip in ClinicalIndicationPanel.objects.filter(
                 clinical_indication_id=ci_id, current=True
@@ -770,7 +772,7 @@ def edit_gene(request, panel_id: int):
     )
 
     if request.method == "POST":
-        selected_gene_ids: list[int] = request.POST.getlist("genes")
+        selected_gene_ids: List[int] = request.POST.getlist("genes")
 
         if selected_gene_ids:
             with transaction.atomic():
@@ -852,7 +854,7 @@ def edit_gene(request, panel_id: int):
             agg_history = list(chain(ci_test_method_history, ci_panels_history))
 
             # fetch genes associated with panel
-            pgs: QuerySet[dict] = (
+            pgs: QuerySet[Dict] = (
                 PanelGene.objects.filter(panel_id=new_panel.id)
                 .values(
                     "gene_id",
@@ -1457,9 +1459,9 @@ def genepanel(request):
     ).values("gene_id__hgnc_id", "gene_id", "panel_id"):
         panel_genes[row["panel_id"]].append((row["gene_id__hgnc_id"], row["gene_id"]))
 
-    list_of_genepanel: list[Genepanel] = []
+    list_of_genepanel: List[Genepanel] = []
     ci_panel_to_genes = collections.defaultdict(list)
-    file_result: list[list[str]] = []
+    file_result: List[List[str]] = []
 
     # for each r code panel combo, we make a list of genes associated with it
     for r_code, panel_list in ci_panels.items():


### PR DESCRIPTION
`python manage.py` was returning errors related to type hinting in some of the subdirectory scripts. 

They're likely to be version incompatibility issues (I'm using 3.8, whereas the `|` syntax for return-statement type hints was added in 3.10, for example), but some may be genuine syntax errors.

With that in mind, I've enforced backwards compatibility/bugfixes by explicitly importing types from the `typing` module wherever possible, and relying on `Union` for multiple-return type hints.

I've opened a `dev` branch off `main` so I could open a `bugfix` branch against `dev`. Please take a look at the changes and let me know if you're happy.

Thanks,

Sophie