### PR TITLE
In 371 created dates

### DIFF
--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -503,6 +503,12 @@ class HgncRelease(models.Model):
         verbose_name="Hgnc Release", max_length=255, unique=True
     )
 
+    created = models.DateTimeField(
+        verbose_name="created",
+        help="date-time of release version's creation in Eris",
+        auto_now_add=True,
+    )
+
     class Meta:
         db_table = "hgnc_release"
 
@@ -756,6 +762,12 @@ class GffRelease(models.Model):
         ReferenceGenome,
         verbose_name="reference genome",
         on_delete=models.PROTECT,
+    )
+
+    created = models.DateTimeField(
+        verbose_name="created",
+        help="date-time of release version's creation in Eris",
+        auto_now_add=True,
     )
 
     class Meta:

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -505,7 +505,7 @@ class HgncRelease(models.Model):
 
     created = models.DateTimeField(
         verbose_name="created",
-        help="date-time of release version's creation in Eris",
+        help_text="date-time of release version's creation in Eris",
         auto_now_add=True,
     )
 
@@ -766,7 +766,7 @@ class GffRelease(models.Model):
 
     created = models.DateTimeField(
         verbose_name="created",
-        help="date-time of release version's creation in Eris",
+        help_text="date-time of release version's creation in Eris",
         auto_now_add=True,
     )
 


### PR DESCRIPTION
Very minor changes:
- Added a 'created' field to GffRelease
- Added a 'created' field to HgncRelease
This is to make up for the fact that these models don't have their own History tables which will track creation dates automatically

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/51)
<!-- Reviewable:end -->
