### PR TITLE
In 349 sanitise panelclass fields

### DIFF
--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -39,17 +39,17 @@ def _populate_nullable_gene_and_regions_fields(
     region: dict,
 ) -> tuple[ModeOfInheritance | None, ModeOfPathogenicity | None, Penetrance | None]:
     """
-    Handles extracting fields which can be nullable.
-    Make these in the db where they exist, but DON'T make them in the db if they are None.
+    Handles extracting fields which are commonly nullable, and are common to both gene
+    and region-parsing.
+    Where the fields exist, make them in the db.
     Strips leading and trailing spaces for strings.
-    Here to save some lines of code.
 
-    :param: region or gene - a dictionary containing attributes such as moi, mop, e.t.c. Values
+    :param: region (or gene) - a dictionary containing attributes such as moi, mop, e.t.c. Values
     might be null
 
     :return: moi_instance, a ModeOfInheritance instance, or None if not applicable
     :return: mop_instance, a ModeOfPathogenicity instance, or None if not applicable
-    :returnL penetrance, a Penetrance instance, or None if not applicable
+    :return: penetrance, a Penetrance instance, or None if not applicable
     """
     inheritance = region.get("mode_of_inheritance")
     if inheritance:

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -35,9 +35,7 @@ from .panelapp import PanelClass, SuperPanelClass
 from django.db import transaction
 
 
-def _handle_nulls_and_blanks_from_json(
-        json_field: str | None
-) -> str | None:
+def _handle_nulls_and_blanks_from_json(json_field: str | None) -> str | None:
     """
     For an attribute extracted from the genes and regions sections
     of the PanelApp API call - check it isn't some variety of none-type data.
@@ -80,14 +78,14 @@ def _populate_nullable_gene_and_regions_fields(
     inheritance = _handle_nulls_and_blanks_from_json(region.get("mode_of_inheritance"))
     if inheritance:
         moi_instance, _ = ModeOfInheritance.objects.get_or_create(
-                mode_of_inheritance=inheritance
-            )
+            mode_of_inheritance=inheritance
+        )
 
     mop = _handle_nulls_and_blanks_from_json(region.get("mode_of_pathogenicity"))
     if mop:
         mop_instance, _ = ModeOfPathogenicity.objects.get_or_create(
-                mode_of_pathogenicity=mop,
-            )
+            mode_of_pathogenicity=mop,
+        )
 
     penetrance = _handle_nulls_and_blanks_from_json(region.get("penetrance"))
     if penetrance:
@@ -263,7 +261,9 @@ def _insert_regions(panel: PanelClass, panel_instance: Panel) -> None:
             penetrance_instance,
         ) = _populate_nullable_gene_and_regions_fields(single_region)
 
-        haplo = _handle_nulls_and_blanks_from_json(single_region.get("haploinsufficiency_score"))
+        haplo = _handle_nulls_and_blanks_from_json(
+            single_region.get("haploinsufficiency_score")
+        )
         if haplo:
             haplo_instance, _ = Haploinsufficiency.objects.get_or_create(
                 haploinsufficiency=haplo,
@@ -271,7 +271,9 @@ def _insert_regions(panel: PanelClass, panel_instance: Panel) -> None:
         else:
             haplo_instance = None
 
-        triplo = _handle_nulls_and_blanks_from_json(single_region.get("triplosensitivity_score"))
+        triplo = _handle_nulls_and_blanks_from_json(
+            single_region.get("triplosensitivity_score")
+        )
         if triplo:
             triplo_instance, _ = Triplosensitivity.objects.get_or_create(
                 triplosensitivity=triplo,

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -270,7 +270,7 @@ def _insert_regions(panel: PanelClass, panel_instance: Panel) -> None:
             details_38["end"] = single_region.get("grch38_coordinates")[1]
             details_38["reference"] = ref_grch38
             coords.append(details_38)
-        
+
         # for each available build - attach Region record to Panel record
         for coord in coords:
             region, _ = Region.objects.get_or_create(

--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -35,15 +35,15 @@ from .panelapp import PanelClass, SuperPanelClass
 from django.db import transaction
 
 
-def _populate_nullable_gene_and_regions_fields(region: dict) -> tuple[ModeOfInheritance | None,
-                                                                      ModeOfPathogenicity | None,
-                                                                      Penetrance | None]:
+def _populate_nullable_gene_and_regions_fields(
+    region: dict,
+) -> tuple[ModeOfInheritance | None, ModeOfPathogenicity | None, Penetrance | None]:
     """
     Handles extracting fields which can be nullable.
     Make these in the db where they exist, but DON'T make them in the db if they are None.
     Strips leading and trailing spaces for strings.
     Here to save some lines of code.
-    
+
     :param: region or gene - a dictionary containing attributes such as moi, mop, e.t.c. Values
     might be null
 
@@ -55,7 +55,8 @@ def _populate_nullable_gene_and_regions_fields(region: dict) -> tuple[ModeOfInhe
     if inheritance:
         inheritance = inheritance.strip()
         moi_instance, _ = ModeOfInheritance.objects.get_or_create(
-            mode_of_inheritance=inheritance)
+            mode_of_inheritance=inheritance
+        )
     else:
         moi_instance = None
 
@@ -161,8 +162,11 @@ def _insert_gene(
             confidence_level=3,  # we only seed level 3 confidence
         )
 
-        moi_instance, mop_instance, penetrance_instance = \
-            _populate_nullable_gene_and_regions_fields(single_gene)
+        (
+            moi_instance,
+            mop_instance,
+            penetrance_instance,
+        ) = _populate_nullable_gene_and_regions_fields(single_gene)
 
         pg_instance, pg_created = PanelGene.objects.get_or_create(
             panel_id=panel_instance.id,
@@ -172,7 +176,9 @@ def _insert_gene(
                 "confidence_id": confidence_instance.id,
                 "moi_id": (moi_instance.id if moi_instance else None),
                 "mop_id": (mop_instance.id if mop_instance else None),
-                "penetrance_id": (penetrance_instance.id if penetrance_instance else None),
+                "penetrance_id": (
+                    penetrance_instance.id if penetrance_instance else None
+                ),
                 "active": True,
             },
         )
@@ -233,8 +239,11 @@ def _insert_regions(panel: PanelClass, panel_instance: Panel) -> None:
             required_overlap=single_region.get("required_overlap_percentage"),
         )
 
-        moi_instance, mop_instance, penetrance_instance = \
-            _populate_nullable_gene_and_regions_fields(single_region)
+        (
+            moi_instance,
+            mop_instance,
+            penetrance_instance,
+        ) = _populate_nullable_gene_and_regions_fields(single_region)
 
         haplo = single_region.get("haploinsufficiency_score")
         if haplo:
@@ -255,7 +264,7 @@ def _insert_regions(panel: PanelClass, panel_instance: Panel) -> None:
         ref_grch37, _ = ReferenceGenome.objects.get_or_create(reference_genome="GRCh37")
         ref_grch38, _ = ReferenceGenome.objects.get_or_create(reference_genome="GRCh38")
 
-        # queue up start and end positions for regions - 
+        # queue up start and end positions for regions -
         # there might be info for build 37, or build 38, or both
         coords = []
         if single_region.get("grch37_coordinates"):

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -866,21 +866,18 @@ class PanelGene(models.Model):
         ModeOfInheritance,
         verbose_name="Mode of inheritance ID",
         on_delete=models.CASCADE,
-        null=True
+        null=True,
     )
 
     mop = models.ForeignKey(
         ModeOfPathogenicity,
         verbose_name="Mode of pathogenicity ID",
         on_delete=models.CASCADE,
-        null=True
+        null=True,
     )
 
     penetrance = models.ForeignKey(
-        Penetrance,
-        verbose_name="Penetrance ID",
-        on_delete=models.CASCADE,
-        null=True
+        Penetrance, verbose_name="Penetrance ID", on_delete=models.CASCADE, null=True
     )
 
     justification = models.TextField(
@@ -1026,35 +1023,32 @@ class Region(models.Model):  # TODO: work out how to split out by transcript
         ModeOfInheritance,
         verbose_name="Mode of inheritance ID",
         on_delete=models.PROTECT,
-        null=True
+        null=True,
     )
 
     mop = models.ForeignKey(
         ModeOfPathogenicity,
         verbose_name="Mode of pathogenicity ID",
         on_delete=models.PROTECT,
-        null=True
+        null=True,
     )
 
     penetrance = models.ForeignKey(
-        Penetrance,
-        verbose_name="Penetrance ID",
-        on_delete=models.PROTECT,
-        null=True
+        Penetrance, verbose_name="Penetrance ID", on_delete=models.PROTECT, null=True
     )
 
     haplo = models.ForeignKey(
         Haploinsufficiency,
         verbose_name="Haploinsufficiency ID",
         on_delete=models.PROTECT,
-        null=True
+        null=True,
     )
 
     triplo = models.ForeignKey(
         Triplosensitivity,
         verbose_name="Triplosensitivity ID",
         on_delete=models.PROTECT,
-        null=True
+        null=True,
     )
 
     overlap = models.ForeignKey(

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -854,18 +854,21 @@ class PanelGene(models.Model):
         ModeOfInheritance,
         verbose_name="Mode of inheritance ID",
         on_delete=models.CASCADE,
+        null=True
     )
 
     mop = models.ForeignKey(
         ModeOfPathogenicity,
         verbose_name="Mode of pathogenicity ID",
         on_delete=models.CASCADE,
+        null=True
     )
 
     penetrance = models.ForeignKey(
         Penetrance,
         verbose_name="Penetrance ID",
         on_delete=models.CASCADE,
+        null=True
     )
 
     justification = models.TextField(
@@ -1011,30 +1014,35 @@ class Region(models.Model):  # TODO: work out how to split out by transcript
         ModeOfInheritance,
         verbose_name="Mode of inheritance ID",
         on_delete=models.PROTECT,
+        null=True
     )
 
     mop = models.ForeignKey(
         ModeOfPathogenicity,
         verbose_name="Mode of pathogenicity ID",
         on_delete=models.PROTECT,
+        null=True
     )
 
     penetrance = models.ForeignKey(
         Penetrance,
         verbose_name="Penetrance ID",
         on_delete=models.PROTECT,
+        null=True
     )
 
     haplo = models.ForeignKey(
         Haploinsufficiency,
         verbose_name="Haploinsufficiency ID",
         on_delete=models.PROTECT,
+        null=True
     )
 
     triplo = models.ForeignKey(
         Triplosensitivity,
         verbose_name="Triplosensitivity ID",
         on_delete=models.PROTECT,
+        null=True
     )
 
     overlap = models.ForeignKey(

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_handle_nulls_and_blanks_from_json.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_handle_nulls_and_blanks_from_json.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
-from requests_app.management.commands._insert_panel import _handle_nulls_and_blanks_from_json
+from requests_app.management.commands._insert_panel import (
+    _handle_nulls_and_blanks_from_json,
+)
 
 
 class TestHandleNullsAndBlanks_CasesEquivalentToNoneData(TestCase):
@@ -9,6 +11,7 @@ class TestHandleNullsAndBlanks_CasesEquivalentToNoneData(TestCase):
     CASES: all these cases feed None or similar data to _handle_nulls_and_blanks_from_json
     EXPECT: all should return None
     """
+
     def test_handle_empty_strings(self):
         region = ""
 
@@ -17,13 +20,13 @@ class TestHandleNullsAndBlanks_CasesEquivalentToNoneData(TestCase):
 
     def test_handle_blank_space_strings(self):
         region = " "
-        
+
         region_out = _handle_nulls_and_blanks_from_json(region)
         assert not region_out
 
     def test_handle_literally_none(self):
         region = None
-        
+
         region_out = _handle_nulls_and_blanks_from_json(region)
         assert not region_out
 
@@ -34,6 +37,7 @@ class TestHandleNullsAndBlanks_CasesWithSomeData(TestCase):
     CASES: all these cases feed a valid string to _handle_nulls_and_blanks_from_json
     EXPECT: all should return a string, with leading/trailing spaces removed if applicable
     """
+
     def test_spaced_out_string(self):
         region = " a nice string "
 

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_handle_nulls_and_blanks_from_json.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_handle_nulls_and_blanks_from_json.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+
+from requests_app.management.commands._insert_panel import _handle_nulls_and_blanks_from_json
+
+
+class TestHandleNullsAndBlanks_CasesEquivalentToNoneData(TestCase):
+    """
+    Basic tests of _handle_nulls_and_blanks_from_json
+    CASES: all these cases feed None or similar data to _handle_nulls_and_blanks_from_json
+    EXPECT: all should return None
+    """
+    def test_handle_empty_strings(self):
+        region = ""
+
+        region_out = _handle_nulls_and_blanks_from_json(region)
+        assert not region_out
+
+    def test_handle_blank_space_strings(self):
+        region = " "
+        
+        region_out = _handle_nulls_and_blanks_from_json(region)
+        assert not region_out
+
+    def test_handle_literally_none(self):
+        region = None
+        
+        region_out = _handle_nulls_and_blanks_from_json(region)
+        assert not region_out
+
+
+class TestHandleNullsAndBlanks_CasesWithSomeData(TestCase):
+    """
+    Basic tests of _handle_nulls_and_blanks_from_json
+    CASES: all these cases feed a valid string to _handle_nulls_and_blanks_from_json
+    EXPECT: all should return a string, with leading/trailing spaces removed if applicable
+    """
+    def test_spaced_out_string(self):
+        region = " a nice string "
+
+        region_out = _handle_nulls_and_blanks_from_json(region)
+        assert region_out == "a nice string"
+
+    def test_straightforward_string(self):
+        region = "easy string"
+
+        region_out = _handle_nulls_and_blanks_from_json(region)
+        assert region_out == region

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_regions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_panel/test_insert_regions.py
@@ -251,7 +251,7 @@ class TestInsertRegions_PreexistingRegion(TestCase):
 
         self.moi = ModeOfInheritance.objects.create(mode_of_inheritance="TEST VALUE")
 
-        self.mop = ModeOfPathogenicity.objects.create(mode_of_pathogenicity=None)
+        self.mop = None
 
         self.variant_type = VariantType.objects.create(variant_type="cnv_test")
 
@@ -261,9 +261,9 @@ class TestInsertRegions_PreexistingRegion(TestCase):
 
         self.overlap = RequiredOverlap.objects.create(required_overlap=600)
 
-        self.penetrance = Penetrance.objects.create(penetrance=None)
+        self.penetrance = None
 
-        self.triplosensitivity = Triplosensitivity.objects.create(triplosensitivity="")
+        self.triplosensitivity = None
 
         self.reference_genome = ReferenceGenome.objects.create(
             reference_genome="GRCh38"
@@ -277,12 +277,12 @@ class TestInsertRegions_PreexistingRegion(TestCase):
             start=3725055,
             end=3880120,
             moi=self.moi,
-            mop_id=self.mop.id,
+            mop_id=self.mop,
             vartype=self.variant_type,
-            confidence_id=self.confidence.id,
+            confidence=self.confidence,
             haplo=self.haploinsufficiency,
             overlap=self.overlap,
-            penetrance_id=self.penetrance.id,
+            penetrance=self.penetrance,
             triplo=self.triplosensitivity,
             type="region",
         )
@@ -382,7 +382,7 @@ class TestInsertRegions_PreexistingLink(TestCase):
 
         self.moi = ModeOfInheritance.objects.create(mode_of_inheritance="TEST VALUE")
 
-        self.mop = ModeOfPathogenicity.objects.create(mode_of_pathogenicity=None)
+        self.mop = None
 
         self.variant_type = VariantType.objects.create(variant_type="cnv_test")
 
@@ -392,9 +392,9 @@ class TestInsertRegions_PreexistingLink(TestCase):
 
         self.overlap = RequiredOverlap.objects.create(required_overlap=600)
 
-        self.penetrance = Penetrance.objects.create(penetrance=None)
+        self.penetrance = None
 
-        self.triplosensitivity = Triplosensitivity.objects.create(triplosensitivity="")
+        self.triplosensitivity = None
 
         self.reference_genome = ReferenceGenome.objects.create(
             reference_genome="GRCh38"
@@ -408,12 +408,12 @@ class TestInsertRegions_PreexistingLink(TestCase):
             start=3725055,
             end=3880120,
             moi=self.moi,
-            mop_id=self.mop.id,
+            mop=self.mop,
             vartype=self.variant_type,
             confidence_id=self.confidence.id,
             haplo=self.haploinsufficiency,
             overlap=self.overlap,
-            penetrance_id=self.penetrance.id,
+            penetrance=self.penetrance,
             triplo=self.triplosensitivity,
             type="region",
         )
@@ -479,6 +479,7 @@ class TestInsertRegions_PreexistingLink(TestCase):
         regions = Region.objects.all()
 
         errors += len_check_wrapper(regions, "regions", 2)
+
         errors += value_check_wrapper(
             regions[0].name, "name of first region", self.first_region.name
         )  # the pre-populated value will show first


### PR DESCRIPTION
Branch to fix ticket IN-349.

When Regions and Genes are made, several foreign key fields such as MOI, MOP, e.t.c. are involved. However, these FK fields in the Region and Gene tables were not nullable, and no string-stripping was carried out, resulting in the creation of database table values such as NULL and empty strings.
This branch fixes this via:
- Making affected FK fields in Gene and Region nullable
- Setting those fields to None rather than making new MOI, MOP, e.t.c. values named NULL
- Blank space-stripping commonly-affected parsed values
- Adjusting existing unit tests to cover these cases

Unit tests are passing:
----------------------------------------------------------------------
Ran 99 tests in 2.543s

OK

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/52)
<!-- Reviewable:end -->
