### PR TITLE
Raise error if args not given in Transcript seed & Changing GeneHgncReleaseHistory.note to Textfield

### DIFF
--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -48,14 +48,6 @@ class Command(BaseCommand):
         :param: file_ids, a list of file ID strings
         """
 
-        # check if the arguments are provided
-        FILES = ["MANE", "G2REFSEQ", "MARKNAME"]
-
-        for idx, file_id in enumerate(file_ids):
-            if file_id is None:
-                raise Exception(f"External file id for {FILES[idx]} is missing!")
-
-        # check if the arguments are valid
         missing_ids = [id for id in file_ids if not re.match(r"^file-[\w]+$", id)]
 
         if missing_ids:
@@ -69,14 +61,7 @@ class Command(BaseCommand):
         Validate that the external releases are in the correct format
         Only numbers and dots are permitted, e.g. 1.0.13
         """
-        # check if arg provided
-        FILES = ["HGNC RELEASE", "MANE RELEASE", "GFF RELEASE", "HGMD RELEASE"]
 
-        for idx, release in enumerate(releases):
-            if release is None:
-                raise Exception(f"External version for {FILES[idx]} is missing!")
-
-        # check if valid
         invalid_releases = [id for id in releases if not re.match(r"^\d+(\.\d+)*$", id)]
 
         if invalid_releases:
@@ -138,6 +123,7 @@ class Command(BaseCommand):
             "--hgnc_release",
             type=str,
             help="The documented release version of the HGNC file",
+            required=True,
         )
         transcript.add_argument(
             "--mane",
@@ -149,11 +135,13 @@ class Command(BaseCommand):
             "--mane_ext_id",
             type=str,
             help="The DNAnexus file ID of the MANE .csv file. Will start with 'file-'",
+            required=True,
         )
         transcript.add_argument(
             "--mane_release",
             type=str,
             help="The documented release version of the MANE file(s)",
+            required=True,
         )
         transcript.add_argument(
             "--gff",
@@ -165,6 +153,7 @@ class Command(BaseCommand):
             "--gff_release",
             type=str,
             help="The documented release version of the GFF file",
+            required=True,
         )
         transcript.add_argument(
             "--g2refseq",
@@ -176,6 +165,7 @@ class Command(BaseCommand):
             "--g2refseq_ext_id",
             type=str,
             help="The file ID of the gene2refseq csv file. Will start with 'file-'",
+            required=True,
         )
         transcript.add_argument(
             "--markname",
@@ -187,11 +177,13 @@ class Command(BaseCommand):
             "--markname_ext_id",
             type=str,
             help="The file ID of the markname csv file. Will start with 'file-'",
+            required=True,
         )
         transcript.add_argument(
             "--hgmd_release",
             type=str,
             help="The documented release version of the HGMD files",
+            required=True,
         )
         transcript.add_argument(
             "--error",

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
 
         for idx, release in enumerate(releases):
             if release is None:
-                raise Exception(f"External file id for {FILES[idx]} is missing!")
+                raise Exception(f"External version for {FILES[idx]} is missing!")
 
         # check if valid
         invalid_releases = [id for id in releases if not re.match(r"^\d+(\.\d+)*$", id)]

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -47,6 +47,15 @@ class Command(BaseCommand):
         Validate that the external file ids are in the correct format
         :param: file_ids, a list of file ID strings
         """
+
+        # check if the arguments are provided
+        FILES = ["MANE", "G2REFSEQ", "MARKNAME"]
+
+        for idx, file_id in enumerate(file_ids):
+            if file_id is None:
+                raise Exception(f"External file id for {FILES[idx]} is missing!")
+
+        # check if the arguments are valid
         missing_ids = [id for id in file_ids if not re.match(r"^file-[\w]+$", id)]
 
         if missing_ids:
@@ -60,6 +69,14 @@ class Command(BaseCommand):
         Validate that the external releases are in the correct format
         Only numbers and dots are permitted, e.g. 1.0.13
         """
+        # check if arg provided
+        FILES = ["HGNC RELEASE", "MANE RELEASE", "GFF RELEASE", "HGMD RELEASE"]
+
+        for idx, release in enumerate(releases):
+            if release is None:
+                raise Exception(f"External file id for {FILES[idx]} is missing!")
+
+        # check if valid
         invalid_releases = [id for id in releases if not re.match(r"^\d+(\.\d+)*$", id)]
 
         if invalid_releases:

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -568,9 +568,9 @@ class GeneHgncReleaseHistory(models.Model):
         auto_now_add=True,
     )
 
-    note = models.CharField(
+    note = models.TextField(
         verbose_name="Note",
-        max_length=255,
+
     )
 
     user = models.CharField(


### PR DESCRIPTION
- recording of alias symbols change in GeneHgncReleaseHistory can be longer than 255 limit thus changed the field to TextField
- seeding `python manage.py seed transcript` should throw an error if arguments such as hgnc_release is not provided

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/53)
<!-- Reviewable:end -->
