### PR TITLE
In 378 superpanel single import

### DIFF
--- a/requests_app/management/commands/_insert_panel.py
+++ b/requests_app/management/commands/_insert_panel.py
@@ -497,14 +497,16 @@ def panel_insert_controller(
     input from the API
     :param: user [str], the user initiating this
     """
-    # currently, only handle Panel/SuperPanel if the panel data is from
-    # PanelApp
+    # currently, we only handle Panel/SuperPanel if the panel data is from
+    # PanelApp, hence adding the source manually
     for panel in panels:
         _insert_panel_data_into_db(panel, user)
 
     for superpanel in superpanels:
         child_panel_instances = []
         for panel in superpanel.child_panels:
+            panel.panel_source = "PanelApp"  # manual addition of source
+
             child_panel_instance, _ = _insert_panel_data_into_db(panel, user)
             child_panel_instances.append(child_panel_instance)
         _insert_superpanel_into_db(superpanel, child_panel_instances, user)

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -245,9 +245,11 @@ class Command(BaseCommand):
                 panel_data.panel_source = "PanelApp"  # manual addition of source
 
                 if is_superpanel:
+                    panels = []
                     superpanels = [panel_data]
                 else:
                     panels = [panel_data]
+                    superpanels = []
 
             if not test_mode:
                 # not printing amounts because there are some duplicates now,

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
             "--td_release",
             type=str,
             help="The documented release version of the test directory file",
-            required=True
+            required=True,
         )
 
         td.add_argument(


### PR DESCRIPTION
I've made minor changes to fix issues with importing single panels or superpanels by IDs:
- Making sure to specify that for a superpanel, the list of panels is an empty list, and vice versa
- Specifying that for child-panels of a superpanel, the panel's source is PanelApp.

Populating with a single SuperPanel ID previously didn't work, but now is fine:

python manage.py seed panelapp 465
Getting latest panel version
Importing panels into database...
Done.

When viewing in a database viewer, the superpanel is in the SuperPanel table, and the child panels are all in the Panel table.

Unit tests are passing:
----------------------------------------------------------------------
Ran 110 tests in 7.352s

OK
Destroying test database for alias 'default'...
