### PR TITLE
HGNCs-type panel naming

### DIFF
--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -353,20 +353,12 @@ def _make_panels_from_hgncs(
     unique_td_source: str = f"{td_source} + {config_source} + {td_release.td_date}"
 
     conf, moi, mop, pen = _retrieve_unknown_metadata_records()
-
-    # make the panel name
-    # the max length of Panel name is 255
-    # if the length of panel_name is more than 255, truncate it to 245
-    # and add TRUNCATED (9 chars) which will be 254 chars in total
-
+    
     panel_name = ",".join(sorted(hgnc_list))
-    formatted_panel_name = (
-        panel_name[:245] + "TRUNCATED" if len(panel_name) > 255 else panel_name
-    )
 
     # create Panel record only when HGNC is different
     panel_instance, panel_created = Panel.objects.get_or_create(
-        panel_name=formatted_panel_name,
+        panel_name=panel_name,
         test_directory=True,
         defaults={
             "panel_source": unique_td_source,

--- a/requests_app/management/commands/seed.py
+++ b/requests_app/management/commands/seed.py
@@ -201,6 +201,7 @@ class Command(BaseCommand):
             "--refgenome",
             type=str,
             help="Reference Genome",
+            required=True,
         )
 
     def handle(self, *args, **kwargs) -> None:

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
@@ -231,4 +231,6 @@ class TestMakePanelsFromHgncs(TestCase):
 
         panel = Panel.objects.first()
 
-        assert len(panel.panel_name) == 254  # assert that panel name length is 200
+        assert len(panel.panel_name) == len(
+            ",".join(hgncs)
+        )  # assert that panel name length is 200

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
@@ -213,24 +213,3 @@ class TestMakePanelsFromHgncs(TestCase):
     # the clinical indication will be linked to it (and both old and new will be flagged for review)
     # this is different from the panel-gene interaction where panel get their genes from PanelApp API
     # thus there's a need to monitor the changes in panel-gene relationship
-
-    def test_long_hgnc_list(self):
-        """
-        scenario where there's a long list of hgncs and db limit for CharField
-        is only 255 chars thus there is a need to limit panel name to 200 chars
-        if length exceed 255
-
-        we expect the function to truncate the panel name to 200 chars and store it in db
-        """
-
-        hgncs = [f"HGNC:{i}" for i in range(1000)]
-
-        _make_panels_from_hgncs(
-            self.first_clinical_indication, self.td_version, hgncs, self.user
-        )
-
-        panel = Panel.objects.first()
-
-        assert len(panel.panel_name) == len(
-            ",".join(hgncs)
-        )  # assert that panel name length is 200


### PR DESCRIPTION
- no need for truncation since now we're using TextField
- `required` on refgenome in transcript seeding

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/59)
<!-- Reviewable:end -->

```
(env) jason@Jasons-MBA eris % python manage.py test
Found 112 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.........Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: True
Data insertion completed.
.Inserting test directory data into database... forced: False
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
.Inserting test directory data into database... forced: False
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
Data insertion completed.
.Inserting test directory data into database... forced: False
.................................For panel Acute rhabdomyolyosis, skipping gene without confidence information: acyl-CoA dehydrogenase family member 9
.For panel Acute rhabdomyolyosis, skipping gene without confidence information: acyl-CoA dehydrogenase family member 9
..For panel Acute rhabdomyolyosis, skipping gene without HGNC ID: acyl-CoA dehydrogenase family member 9
................................Start gene bulk create: 15:47:01
....................Start gene alias bulk update: 15:47:01
.Start gene symbol bulk update: 15:47:01
.Start gene symbol bulk update: 15:47:01
.
----------------------------------------------------------------------
Ran 112 tests in 8.715s

OK
Destroying test database for alias 'default'...
```
