### PR TITLE
In 382 sanitise insert ci

### DIFF
--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -17,10 +17,6 @@ from requests_app.models import (
     ClinicalIndicationSuperPanel,
     ClinicalIndicationSuperPanelHistory,
     Gene,
-    Confidence,
-    Penetrance,
-    ModeOfInheritance,
-    ModeOfPathogenicity,
     PanelGene,
     ClinicalIndicationPanelHistory,
     ClinicalIndicationTestMethodHistory,
@@ -287,25 +283,20 @@ def _retrieve_superpanel_from_pa_id(pa_id: str) -> SuperPanel | None:
 
 
 def _retrieve_unknown_metadata_records() -> (
-    tuple[Confidence, ModeOfInheritance, ModeOfPathogenicity, Penetrance]
+    tuple[None, None, None, None]
 ):
     """
-    Retrieve additional metadata records for PanelGene records
-
+    Set unknown metadata records, as used when making panels from HGNCs, to None
     :returns:
-        conf [Confidence record]
-        moi [ModeOfInheritance record]
-        mop [ModeOfPathogenicity record]
-        pen [Penetrance record]
+        conf: None
+        moi: None
+        mop: None
+        pen: None
     """
-
-    conf, _ = Confidence.objects.get_or_create(confidence_level=None)
-
-    moi, _ = ModeOfInheritance.objects.get_or_create(mode_of_inheritance=None)
-
-    mop, _ = ModeOfPathogenicity.objects.get_or_create(mode_of_pathogenicity=None)
-
-    pen, _ = Penetrance.objects.get_or_create(penetrance=None)
+    conf = None
+    moi = None
+    mop = None
+    pen = None
 
     return conf, moi, mop, pen
 
@@ -386,10 +377,10 @@ def _make_panels_from_hgncs(
         pg_instance, created = PanelGene.objects.get_or_create(
             panel_id=panel_instance.id,
             gene_id=gene_instance.id,
-            confidence_id=conf.id,
-            moi_id=moi.id,
-            mop_id=mop.id,
-            penetrance_id=pen.id,
+            confidence=conf,
+            moi=moi,
+            mop=mop,
+            penetrance=pen,
             active=True,  # this should be True because it's linking HGNC panel to HGNC
             defaults={
                 "justification": unique_td_source,

--- a/requests_app/management/commands/_insert_ci.py
+++ b/requests_app/management/commands/_insert_ci.py
@@ -282,9 +282,7 @@ def _retrieve_superpanel_from_pa_id(pa_id: str) -> SuperPanel | None:
     return panel_instance
 
 
-def _retrieve_unknown_metadata_records() -> (
-    tuple[None, None, None, None]
-):
+def _retrieve_unknown_metadata_records() -> tuple[None, None, None, None]:
     """
     Set unknown metadata records, as used when making panels from HGNCs, to None
     :returns:
@@ -344,7 +342,7 @@ def _make_panels_from_hgncs(
     unique_td_source: str = f"{td_source} + {config_source} + {td_release.td_date}"
 
     conf, moi, mop, pen = _retrieve_unknown_metadata_records()
-    
+
     panel_name = ",".join(sorted(hgnc_list))
 
     # create Panel record only when HGNC is different

--- a/requests_app/models.py
+++ b/requests_app/models.py
@@ -942,6 +942,7 @@ class PanelGene(models.Model):
         Confidence,
         verbose_name="Confidence ID",
         on_delete=models.CASCADE,
+        null=True,
     )
 
     moi = models.ForeignKey(

--- a/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
+++ b/tests/tests_requests_app/test_management/test_commands/test_insert_ci/test_smaller_functions.py
@@ -426,10 +426,10 @@ class TestRetrieveUnknownMetadataRecords(TestCase):
 
     conf, moi, mop, pen = _retrieve_unknown_metadata_records()
 
-    assert conf.confidence_level == None
-    assert moi.mode_of_inheritance == None
-    assert mop.mode_of_pathogenicity == None
-    assert pen.penetrance == None
+    assert not conf
+    assert not moi
+    assert not mop
+    assert not pen
 
 
 class TestMakeProvisionalTestMethodChange(TestCase):


### PR DESCRIPTION
In an earlier branch, I sanitised some inputs for panel-creation, such as MOI and MOP, which can be null in PanelApp. However, I missed that when panels are made from HGNC IDs in the test directory (see insert_ci), None-rows are inserted into the database for unknown attributes, rather than using the nullable type. On this branch I:
- Made the confidence FK column nullable in PanelGene
- Made it so that confidence, moi, mop and penetrance all set to None when a PanelGene is being created from a test directory upload
- Adjusted affected unit tests

Migrations are working without errors, seeding is working, and unit tests pass:
----------------------------------------------------------------------
Ran 111 tests in 5.253s

OK
Destroying test database for alias 'default'...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/60)
<!-- Reviewable:end -->
