### PR TITLE
In 414 change intrapanel delimiter

### DIFF
--- a/panels_backend/management/commands/_insert_ci.py
+++ b/panels_backend/management/commands/_insert_ci.py
@@ -341,7 +341,7 @@ def _make_panels_from_hgncs(
 
     conf, moi, mop, pen = _retrieve_unknown_metadata_records()
 
-    panel_name = ",".join(sorted(hgnc_list))
+    panel_name = "&".join(sorted(hgnc_list))
 
     # create Panel record only when HGNC is different
     panel_instance, panel_created = Panel.objects.get_or_create(

--- a/panels_web/forms.py
+++ b/panels_web/forms.py
@@ -62,6 +62,14 @@ class PanelForm(forms.Form):
         panel_name: str = self.cleaned_data.get("panel_name")
 
         if panel_name:
+            # ensure the user can't use characters which may cause downstream workbook parsing issues
+            forbidden_strings = [",", ";", "&"]
+            if any(substring in panel_name for substring in forbidden_strings):
+                self.add_error(
+                    "panel_name",
+                    f"The panel contains disallowed characters: {' '.join(forbidden_strings)}. Please choose a different name.",
+                )
+
             p = Panel.objects.filter(panel_name__iexact=panel_name)
 
             if p:

--- a/tests/test_panels_backend/test_management/test_commands/test_insert_ci/test_insert_test_directory_data.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_insert_ci/test_insert_test_directory_data.py
@@ -518,7 +518,7 @@ class TestInsertTestDirectoryData(TestCase):
         """
         test when a clinical indication have hgncs as panel
         expect function to create or use existing clinical indication (R123 is already in the db from setup)
-        expect function to create a new panel (HGNC:1,HGNC:2) and link those two together
+        expect function to create a new panel (HGNC:1&HGNC:2) and link those two together
         """
 
         errors = []
@@ -551,7 +551,7 @@ class TestInsertTestDirectoryData(TestCase):
         errors += value_check_wrapper(
             clinical_indication_panels[1]["panel_id__panel_name"],
             "clinical indication panel name",
-            "HGNC:1,HGNC:2",
+            "HGNC:1&HGNC:2",
         )
 
         errors += value_check_wrapper(
@@ -568,17 +568,17 @@ class TestInsertTestDirectoryData(TestCase):
         what if the same clinical indication (R123) changes its hgncs in the next test directory
 
         example:
-            R123 is linked to panel (HGNC:1,HGNC:2) - already in db
+            R123 is linked to panel (HGNC:1&HGNC:2) - already in db
             in next test directory, R123 have panels: [HGNC:1, HGNC:3]
 
-        we expect the function to make a new panel HGNC1,HGNC3 and link it to R123
+        we expect the function to make a new panel HGNC1&HGNC3 and link it to R123
         then flag both links for review
         """
 
         errors = []
 
         mock_panel = Panel.objects.create(
-            panel_name="HGNC:1,HGNC:2",
+            panel_name="HGNC:1&HGNC:2",
             test_directory=True,  # notice this is True. All panels that come from test directory especially hgncs have this value as True
         )
 
@@ -591,7 +591,7 @@ class TestInsertTestDirectoryData(TestCase):
             panel_id=mock_panel.id,
             clinical_indication_id=mock_clinical_indication.id,
             current=True,
-        )  # make a mock link between R123 and HGNC:1,HGNC:2
+        )  # make a mock link between R123 and HGNC:1&HGNC:2
 
         mock_test_directory = {
             "indications": [
@@ -627,8 +627,8 @@ class TestInsertTestDirectoryData(TestCase):
         ).values("panel_id__panel_name", "clinical_indication_id__r_code", "pending")
 
         # NOTE: the first clinical indication-panel link is made in setup above
-        # the second link is made between R234 and HGNC:1,HGNC:2
-        # we expect the third link to be made by the function between R234 and HGNC:1,HGNC:3
+        # the second link is made between R234 and HGNC:1&HGNC:2
+        # we expect the third link to be made by the function between R234 and HGNC:1&HGNC:3
 
         errors += len_check_wrapper(
             clinical_indication_panels, "clinical indication-panel", 3
@@ -655,14 +655,14 @@ class TestInsertTestDirectoryData(TestCase):
         errors += value_check_wrapper(
             clinical_indication_panels[2]["panel_id__panel_name"],
             "third clinical indication-panel panel name",
-            "HGNC:1,HGNC:3",
-        )  # R234 linked to HGNC:1,HGNC:3
+            "HGNC:1&HGNC:3",
+        )  # R234 linked to HGNC:1&HGNC:3
 
         errors += value_check_wrapper(
             clinical_indication_panels[2]["clinical_indication_id__r_code"],
             "third clinical indication-panel r code",
             "R234",
-        )  # R234 linked to HGNC:1,HGNC:3
+        )  # R234 linked to HGNC:1&HGNC:3
 
         assert not errors, errors
 

--- a/tests/test_panels_backend/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_insert_ci/test_make_panels_from_hgncs.py
@@ -75,8 +75,8 @@ class TestMakePanelsFromHgncs(TestCase):
         errors += value_check_wrapper(
             panels[0].panel_name,
             "panel name",
-            "HGNC:1,HGNC:2",
-        )  # panel name should be the list of hgncs joined by comma
+            "HGNC:1&HGNC:2",
+        )  # panel name should be the list of hgncs joined by an ampersand
 
         errors += value_check_wrapper(
             panels[0].test_directory,

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_prepare_gene2refseq_file.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_prepare_gene2refseq_file.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
-from panels_backend.management.commands._parse_transcript import _prepare_gene2refseq_file
+from panels_backend.management.commands._parse_transcript import (
+    _prepare_gene2refseq_file,
+)
 
 
 class TestPrepareGene2RefSeqFile(TestCase):


### PR DESCRIPTION
Changes:
- When a panel is made from Test Directory, the name is now made by joining HGNCs with '&' instead of ','
- Added validation checks to the PanelForm, so users can't put common delimiters in the names of their custom panels
- Changed unit tests affected by the above

Ran 136 tests in 4.419s

OK

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/75)
<!-- Reviewable:end -->
