### PR TITLE
In 417 ensure correct output file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ python manage.py generate genepanels --hgnc testing_files/eris/hgnc_dump_2023060
 ```
 To run with a specified output pathway:
 ```
-python manage.py generate genepanels --hgnc testing_files/eris/hgnc_dump_23052023.txt --output <output_path>
+python manage.py generate genepanels --hgnc testing_files/eris/hgnc_dump_20230606_1.txt --output <output_path>
 ```
 
 #### Generate a g2t file

--- a/panels_backend/management/commands/_insert_ci.py
+++ b/panels_backend/management/commands/_insert_ci.py
@@ -323,7 +323,7 @@ def _make_panels_from_hgncs(
     unique_td_source: str = f"{td_source} + {config_source} + {td_release.td_date}"
 
     conf = moi = mop = pen = None
-
+    
     panel_name = "&".join(sorted(hgnc_list))
 
     # create Panel record only when HGNC is different
@@ -333,7 +333,7 @@ def _make_panels_from_hgncs(
         defaults={
             "panel_source": unique_td_source,
             "external_id": None,
-            "panel_version": None,
+            "panel_version": "1.0", #test directory doesn't have versioning of its gene lists - give it 1.0
         },
     )
 

--- a/panels_backend/management/commands/_insert_ci.py
+++ b/panels_backend/management/commands/_insert_ci.py
@@ -323,7 +323,7 @@ def _make_panels_from_hgncs(
     unique_td_source: str = f"{td_source} + {config_source} + {td_release.td_date}"
 
     conf = moi = mop = pen = None
-    
+
     panel_name = "&".join(sorted(hgnc_list))
 
     # create Panel record only when HGNC is different
@@ -333,7 +333,7 @@ def _make_panels_from_hgncs(
         defaults={
             "panel_source": unique_td_source,
             "external_id": None,
-            "panel_version": "1.0", #test directory doesn't have versioning of its gene lists - give it 1.0
+            "panel_version": "1.0",  # test directory doesn't have versioning of its gene lists - give it 1.0
         },
     )
 

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -444,7 +444,7 @@ class Command(BaseCommand):
             transcript_data = {
                 "hgnc_id": transcript.gene.hgnc_id,
                 "transcript": transcript.transcript,
-                "clinical": ["clinical_transcript" if clinical_status else "not_clinical_transcript"],
+                "clinical": "clinical_transcript" if clinical_status else "not_clinical_transcript",
             }
             results.append(transcript_data)
 

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -211,11 +211,7 @@ class Command(BaseCommand):
                 # for each panel associated with that clinical indication
                 panel_id: str = panel_dict["ci_panel__panel_id"]
                 # get the PanelApp external ID if there is one. If it's none, make it a blank string
-                panelapp_id: str = (
-                    panel_dict["ci_panel__panel__external_id"]
-                    if panel_dict["ci_panel__panel__external_id"]
-                    else ""
-                )
+                panelapp_id: panel_dict.get("ci_panel__panel__external_id", "")
                 ci_name: str = panel_dict["ci_panel__clinical_indication_id__name"]
                 for hgnc in panel_genes[panel_id]:
                     # for each gene associated with that panel
@@ -223,16 +219,14 @@ class Command(BaseCommand):
                         continue
 
                     # process the panel version
-                    panel_version: str = (
-                        normalize_version(panel_dict["ci_panel__panel__panel_version"])
-                        if panel_dict["ci_panel__panel__panel_version"]
-                        else None
+                    panel_version: str = normalize_version(
+                        panel_dict.get("ci_panel__panel__panel_version", None)
                     )
                     line = [
                         f"{r_code}_{ci_name}",
                         f"{panel_dict['ci_panel__panel__panel_name']}_{panel_version}",
                         hgnc,
-                        f"{panelapp_id}",
+                        panelapp_id,
                     ]
                     results.append(line)
         results = sorted(results, key=lambda x: [x[0], x[1], x[2]])
@@ -287,7 +281,7 @@ class Command(BaseCommand):
                             f"{r_code}_{ci_name}",
                             f"{panel_dict['ci_superpanel__superpanel__panel_name']}_{panel_version}",
                             hgnc,
-                            f"{panelapp_id}",
+                            panelapp_id,
                         ]
                     )
         results = sorted(results, key=lambda x: [x[0], x[1], x[2]])
@@ -453,13 +447,13 @@ class Command(BaseCommand):
             clinical_status = self.get_current_transcript_clinical_status_for_g2t(
                 transcript, latest_select, latest_plus_clinical, latest_hgmd
             )
-            # TODO: add a canonical/non_canonical column
+            displayable_clinical_status = (
+                "clinical_transcript" if clinical_status else "not_clinical_transcript"
+            )
             transcript_data = {
                 "hgnc_id": transcript.gene.hgnc_id,
                 "transcript": transcript.transcript,
-                "clinical": "clinical_transcript"
-                if clinical_status
-                else "not_clinical_transcript",
+                "clinical": displayable_clinical_status,
             }
             results.append(transcript_data)
 

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -260,11 +260,11 @@ class Command(BaseCommand):
             for panel_dict in panel_list:
                 # for each panel associated with that clinical indication
                 panel_id: str = panel_dict["ci_superpanel__superpanel"]
-                panelapp_id: str = (
-                    panel_dict["ci_superpanel__superpanel__external_id"]
-                    if panel_dict["ci_superpanel__superpanel__external_id"]
-                    else ""
+                panelapp_id: str = panel_dict.get(
+                    "ci_superpanel__superpanel__external_id", ""
                 )
+                if not panelapp_id:
+                    panelapp_id = ""
                 ci_name: str = panel_dict["ci_superpanel__clinical_indication__name"]
 
                 for hgnc in panel_genes[panel_id]:

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -210,8 +210,10 @@ class Command(BaseCommand):
             for panel_dict in panel_list:
                 # for each panel associated with that clinical indication
                 panel_id: str = panel_dict["ci_panel__panel_id"]
-                # get the PanelApp external ID if there is one. If it's none, make it a blank string
-                panelapp_id: panel_dict.get("ci_panel__panel__external_id", "")
+                # get the PanelApp external ID if there is one. If it's None, make it a blank string
+                panelapp_id: str = panel_dict.get("ci_panel__panel__external_id", "")
+                if not panelapp_id:
+                    panelapp_id = ""
                 ci_name: str = panel_dict["ci_panel__clinical_indication_id__name"]
                 for hgnc in panel_genes[panel_id]:
                     # for each gene associated with that panel
@@ -219,9 +221,11 @@ class Command(BaseCommand):
                         continue
 
                     # process the panel version
-                    panel_version: str = normalize_version(
-                        panel_dict.get("ci_panel__panel__panel_version", None)
+                    panel_version: str = panel_dict.get(
+                        "ci_panel__panel__panel_version", ""
                     )
+                    if not panel_version:
+                        panel_version = ""
                     line = [
                         f"{r_code}_{ci_name}",
                         f"{panel_dict['ci_panel__panel__panel_name']}_{panel_version}",

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -210,7 +210,8 @@ class Command(BaseCommand):
             for panel_dict in panel_list:
                 # for each panel associated with that clinical indication
                 panel_id: str = panel_dict["ci_panel__panel_id"]
-                panel_panelapp_id: str = panel_dict["ci_panel__panel__external_id"]
+                # get the PanelApp external ID if there is one. If it's none, make it a blank string
+                panelapp_id: str = (panel_dict["ci_panel__panel__external_id"] if panel_dict["ci_panel__panel__external_id"] else "")
                 ci_name: str = panel_dict["ci_panel__clinical_indication_id__name"]
                 for hgnc in panel_genes[panel_id]:
                     # for each gene associated with that panel
@@ -227,7 +228,7 @@ class Command(BaseCommand):
                         f"{r_code}_{ci_name}",
                         f"{panel_dict['ci_panel__panel__panel_name']}_{panel_version}",
                         hgnc,
-                        f"{panel_dict['ci_panel__panel__external_id']}"
+                        f"{panelapp_id}"
                     ]
                     results.append(line)
         results = sorted(results, key=lambda x: [x[0], x[1], x[2]])

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -210,6 +210,7 @@ class Command(BaseCommand):
             for panel_dict in panel_list:
                 # for each panel associated with that clinical indication
                 panel_id: str = panel_dict["ci_panel__panel_id"]
+                panel_panelapp_id: str = panel_dict["ci_panel__panel__external_id"]
                 ci_name: str = panel_dict["ci_panel__clinical_indication_id__name"]
                 for hgnc in panel_genes[panel_id]:
                     # for each gene associated with that panel
@@ -226,6 +227,7 @@ class Command(BaseCommand):
                         f"{r_code}_{ci_name}",
                         f"{panel_dict['ci_panel__panel__panel_name']}_{panel_version}",
                         hgnc,
+                        f"{panel_dict['ci_panel__panel__external_id']}"
                     ]
                     results.append(line)
         results = sorted(results, key=lambda x: [x[0], x[1], x[2]])
@@ -441,6 +443,7 @@ class Command(BaseCommand):
             clinical_status = self.get_current_transcript_clinical_status_for_g2t(
                 transcript, latest_select, latest_plus_clinical, latest_hgmd
             )
+            #TODO: add a canonical/non_canonical column
             transcript_data = {
                 "hgnc_id": transcript.gene.hgnc_id,
                 "transcript": transcript.transcript,

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -444,7 +444,7 @@ class Command(BaseCommand):
             transcript_data = {
                 "hgnc_id": transcript.gene.hgnc_id,
                 "transcript": transcript.transcript,
-                "clinical": clinical_status,
+                "clinical": ["clinical_transcript" if clinical_status else "not_clinical_transcript"],
             }
             results.append(transcript_data)
 
@@ -538,7 +538,7 @@ class Command(BaseCommand):
 
             try:
                 # if the genome is valid, run the controller function, _generate_g2t
-                genome = ReferenceGenome.objects.get(reference_genome=parsed_genome)
+                genome = ReferenceGenome.objects.get(name=parsed_genome)
             except ObjectDoesNotExist:
                 raise ObjectDoesNotExist(
                     "Aborting g2t: reference genome does not exist in the database"

--- a/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genepanels.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genepanels.py
@@ -41,10 +41,10 @@ class TestFormatOutputDataGenepanels(TestCase):
             ci_panels, panel_genes, excluded_hgncs
         )
         expected = [
-            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:1", "109"],
-            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:2", "109"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:3", "209"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:4", "209"],
+            ["R123.2_Condition 1", "First Panel_5", "HGNC:1", "109"],
+            ["R123.2_Condition 1", "First Panel_5", "HGNC:2", "109"],
+            ["R2_Condition 2", "Second Panel_2", "HGNC:3", "209"],
+            ["R2_Condition 2", "Second Panel_2", "HGNC:4", "209"],
         ]
         self.assertEqual(expected, actual)
 
@@ -65,7 +65,7 @@ class TestFormatOutputDataGenepanels(TestCase):
                     "ci_panel__panel_id": 1,
                     "ci_panel__panel__external_id": "109",
                     "ci_panel__panel__panel_name": "First Panel",
-                    "ci_panel__panel__panel_version": "5",
+                    "ci_panel__panel__panel_version": "5.0",
                 }
             ],
             "R2": [
@@ -109,7 +109,7 @@ class TestFormatOutputDataGenepanels(TestCase):
                     "ci_panel__panel_id": 1,
                     "ci_panel__panel__external_id": "109",
                     "ci_panel__panel__panel_name": "First Panel",
-                    "ci_panel__panel__panel_version": "5",
+                    "ci_panel__panel__panel_version": "5.0",
                 }
             ],
             "R2": [
@@ -119,7 +119,7 @@ class TestFormatOutputDataGenepanels(TestCase):
                     "ci_panel__panel_id": 2,
                     "ci_panel__panel__external_id": "209",
                     "ci_panel__panel__panel_name": "Second Panel",
-                    "ci_panel__panel__panel_version": "2",
+                    "ci_panel__panel__panel_version": "2.0",
                 }
             ],
         }

--- a/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genepanels.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genepanels.py
@@ -9,7 +9,7 @@ class TestFormatOutputDataGenepanels(TestCase):
         CASE: Two Clinical Indications are provided with links to 1 panel each. Each panel contains 2 genes.
         None of the genes are on the 'exclude' list (e.g. due to being mitochondrial).
         EXPECT: Return a 4-entry list-of-lists which captures the CI's R code/name, the panel's name and version,
-        and the HGNC on each line.
+        the HGNC, and the PanelApp version on each line.
         """
         ci_panels = {
             "R123.2": [
@@ -41,10 +41,56 @@ class TestFormatOutputDataGenepanels(TestCase):
             ci_panels, panel_genes, excluded_hgncs
         )
         expected = [
-            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:1"],
-            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:2"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:3"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:4"],
+            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:1", "109"],
+            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:2", "109"],
+            ["R2_Condition 2", "Second Panel_2.0", "HGNC:3", "209"],
+            ["R2_Condition 2", "Second Panel_2.0", "HGNC:4", "209"],
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_includes_non_panelapp_panel(self):
+        """
+        CASE: Two Clinical Indications are provided with links to 1 panel each. Each panel contains 2 genes.
+        None of the genes are on the 'exclude' list (e.g. due to being mitochondrial).
+        One panel is from PanelApp, one isn't
+        EXPECT: Return a 4-entry list-of-lists which captures the CI's R code/name, the panel's name and version,
+        the HGNC, and the PanelApp version on each line. For the NOT PanelApp-derived panel, then the PanelApp version
+        will be a blank line.
+        """
+        ci_panels = {
+            "R123.2": [
+                {
+                    "ci_panel__clinical_indication__r_code": "R1",
+                    "ci_panel__clinical_indication_id__name": "Condition 1",
+                    "ci_panel__panel_id": 1,
+                    "ci_panel__panel__external_id": "109",
+                    "ci_panel__panel__panel_name": "First Panel",
+                    "ci_panel__panel__panel_version": "5",
+                }
+            ],
+            "R2": [
+                {
+                    "ci_panel__clinical_indication__r_code": "R2",
+                    "ci_panel__clinical_indication_id__name": "Condition 2",
+                    "ci_panel__panel_id": 2,
+                    "ci_panel__panel__external_id": None,
+                    "ci_panel__panel__panel_name": "HGNC:3&HGNC:4",
+                    "ci_panel__panel__panel_version": "1.0",
+                }
+            ],
+        }
+
+        panel_genes = {1: ["HGNC:1", "HGNC:2"], 2: ["HGNC:3", "HGNC:4"]}
+        excluded_hgncs = set([])
+        cmd = Command()
+        actual = cmd._format_output_data_genepanels(
+            ci_panels, panel_genes, excluded_hgncs
+        )
+        expected = [
+            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:1", "109"],
+            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:2", "109"],
+            ["R2_Condition 2", "HGNC:3&HGNC:4_1.0", "HGNC:3", ""],
+            ["R2_Condition 2", "HGNC:3&HGNC:4_1.0", "HGNC:4", ""],
         ]
         self.assertEqual(expected, actual)
 
@@ -53,7 +99,7 @@ class TestFormatOutputDataGenepanels(TestCase):
         CASE: Two Clinical Indications are provided with links to 1 panel each. Each panel contains 2 genes.
         ONE of the genes is on the 'exclude' list (e.g. due to being mitochondrial).
         EXPECT: Return a 3-entry list-of-lists which captures the CI's R code/name, the panel's name and version,
-        and the HGNC on each line. The line for the 'exclude' list HGNC isn't present.
+        the HGNC, and the PanelApp panel ID on each line. The line for the 'exclude' list HGNC isn't present.
         """
         ci_panels = {
             "R123.2": [
@@ -85,8 +131,8 @@ class TestFormatOutputDataGenepanels(TestCase):
             ci_panels, panel_genes, excluded_hgncs
         )
         expected = [
-            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:2"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:3"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:4"],
+            ["R123.2_Condition 1", "First Panel_5.0", "HGNC:2", "109"],
+            ["R2_Condition 2", "Second Panel_2.0", "HGNC:3", "209"],
+            ["R2_Condition 2", "Second Panel_2.0", "HGNC:4", "209"],
         ]
         self.assertEqual(expected, actual)

--- a/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
@@ -42,10 +42,10 @@ class TestFormatGeneSuperPanels(TestCase):
         }
 
         expected = [
-            ["R1_Condition 1", "First Panel_5.0", "HGNC:300"],
-            ["R1_Condition 1", "First Panel_5.0", "HGNC:910"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:100"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:300"],
+            ["R1_Condition 1", "First Panel_5.0", "HGNC:300", "109"],
+            ["R1_Condition 1", "First Panel_5.0", "HGNC:910", "109"],
+            ["R2_Condition 2", "Second Panel_2.0", "HGNC:100", "209"],
+            ["R2_Condition 2", "Second Panel_2.0", "HGNC:300", "209"],
         ]
 
         cmd = Command()
@@ -92,8 +92,8 @@ class TestFormatGeneSuperPanels(TestCase):
         }
 
         expected = [
-            ["R1_Condition 1", "First Panel_5.0", "HGNC:910"],
-            ["R2_Condition 2", "Second Panel_2.0", "HGNC:100"],
+            ["R1_Condition 1", "First Panel_5.0", "HGNC:910", "109"],
+            ["R2_Condition 2", "Second Panel_2.0", "HGNC:100", "209"],
         ]
 
         cmd = Command()


### PR DESCRIPTION
## Changes
- genepanels: Test directory panels now are made with version 1.0 by default, not None
- genepanels: PanelApp external IDs provided for PanelApp-derived IDs
- g2t: Transcript status back to being 'clinical_transcript' or 'not_clinical_transcript' (rather than True or False)

## Example output files
Example genepanels output based on mid-2023 test directory:

R211.1_Inherited polyposis and early onset colorectal cancer - germline testing	Inherited polyposis and early onset colorectal cancer - germline testing_2.0	HGNC:9588	504
R212.1_Peutz Jeghers Syndrome	HGNC:11389_1.0	HGNC:11389	

Example g2t output based on mid-2023 test directory. N.B I have not yet worked on making g2t align with VEP, so expect transcripts that might not be present in the VEP's GFF file:

HGNC:2186       NM_080630.4     not_clinical_transcript
HGNC:2186       NM_001190709.2  not_clinical_transcript
HGNC:2186       NM_001854.4     clinical_transcript
HGNC:2186       NM_080629.3     not_clinical_transcript
HGNC:2187       NM_080680.3     clinical_transcript
HGNC:2187       NM_001163771.2  not_clinical_transcript

## Unit tests
Ran 137 tests in 4.147s

OK
Destroying test database for alias 'default'...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/81)
<!-- Reviewable:end -->
