### PR TITLE
In 435 accept genome patch versions

### DIFF
--- a/panels_backend/management/commands/_insert_panel.py
+++ b/panels_backend/management/commands/_insert_panel.py
@@ -9,7 +9,6 @@ from panels_backend.models import (
     ClinicalIndicationPanel,
     ClinicalIndicationPanelHistory,
     Gene,
-    Chromosome,
     Confidence,
     Penetrance,
     ModeOfInheritance,

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -894,7 +894,7 @@ def _parse_reference_genome(ref_genome: str) -> str:
     else:
         # check for valid patch notation, in which build is followed by .p and a number, e.g. GRCh37.p13
         splits = ref_genome.lower().split(".")
-        if splits[0] in ["grch37", "grch38"]:            
+        if splits[0] in ["grch37", "grch38"]:
             if re.match(r"^p\d+$", splits[1]):
                 return ref_genome.lower()
         raise ValueError(

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -892,10 +892,15 @@ def _parse_reference_genome(ref_genome: str) -> str:
     elif ref_genome.lower() in permitted_grch38:
         return "GRCh38"
     else:
+        # check for valid patch notation, in which build is followed by .p and a number, e.g. GRCh37.p13
+        splits = ref_genome.lower().split(".")
+        if splits[0] in ["grch37", "grch38"]:            
+            if re.match(r"^p\d+$", splits[1]):
+                return ref_genome.lower()
         raise ValueError(
             f"Please provide a valid reference genome,"
-            f" such as {'; '.join(permitted_grch37)} or "
-            f"{'; '.join(permitted_grch38)} - you provided {ref_genome}"
+            f" such as {'; '.join(permitted_grch37)}, {'; '.join(permitted_grch38)} "
+            f" or GRCh37/GRCh38 followed by '.p' patch numbers - you provided {ref_genome}"
         )
 
 

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -893,10 +893,13 @@ def _parse_reference_genome(ref_genome: str) -> str:
         return "GRCh38"
     else:
         # check for valid patch notation, in which build is followed by .p and a number, e.g. GRCh37.p13
-        splits = ref_genome.lower().split(".")
-        if splits[0] in ["grch37", "grch38"]:
-            if re.match(r"^p\d+$", splits[1]):
-                return ref_genome.lower()
+        splits = ref_genome.split(".")
+        if splits[0].lower() in permitted_grch37:
+            if re.match(r"^p\d+$", splits[1].lower()):
+                return f"GRCh37.{splits[1].lower()}"
+        elif splits[0].lower() in permitted_grch38:
+            if re.match(r"^p\d+$", splits[1].lower()):
+                return f"GRCh38.{splits[1].lower()}"
         raise ValueError(
             f"Please provide a valid reference genome,"
             f" such as {'; '.join(permitted_grch37)}, {'; '.join(permitted_grch38)} "

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_reference_genome.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_reference_genome.py
@@ -24,10 +24,10 @@ class TestParsingRefGenome(TestCase):
         """
         Check valid synonyms for GRCh37 are converted
         """
-        valid = ["GRCh37.p10", "Grch37.p10"]
+        valid = ["GRCh37.p10", "Grch37.P10", "hg19.P10"]
         for i in valid:
             with self.subTest():
-                self.assertEqual(_parse_reference_genome(i), "grch37.p10")
+                self.assertEqual(_parse_reference_genome(i), "GRCh37.p10")
 
     def test_ref_genome_values_38(self):
         """
@@ -38,20 +38,26 @@ class TestParsingRefGenome(TestCase):
             with self.subTest():
                 self.assertEqual(_parse_reference_genome(i), "GRCh38")
 
-    def test_ref_genome_values_37_with_patch(self):
+    def test_ref_genome_values_38_with_patch(self):
         """
         Check valid synonyms for GRCh37 are converted
         """
-        valid = ["GRCh38.p10", "Grch38.p10"]
+        valid = ["GRCh38.p10", "Grch38.p10", "hg38.P10"]
         for i in valid:
             with self.subTest():
-                self.assertEqual(_parse_reference_genome(i), "grch38.p10")
+                self.assertEqual(_parse_reference_genome(i), "GRCh38.p10")
 
     def test_invalid_ref_genomes(self):
         """
         Check that nonsense strings throw a ValueError and a handy message
         """
-        invalid = ["1234", "beans", "£&£*$", "hg19.p10", "GRCh37.p12not_a_real_patch", "GRCh38.p12not_a_real_patch"]
+        invalid = [
+            "1234",
+            "beans",
+            "£&£*$",
+            "GRCh37.p12not_a_real_patch",
+            "GRCh38.p12not_a_real_patch",
+        ]
 
         permitted_grch37 = ["hg19", "37", "grch37"]
         permitted_grch38 = ["hg38", "38", "grch38"]

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_reference_genome.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_reference_genome.py
@@ -20,6 +20,15 @@ class TestParsingRefGenome(TestCase):
             with self.subTest():
                 self.assertEqual(_parse_reference_genome(i), "GRCh37")
 
+    def test_ref_genome_values_37_with_patch(self):
+        """
+        Check valid synonyms for GRCh37 are converted
+        """
+        valid = ["GRCh37.p10", "Grch37.p10"]
+        for i in valid:
+            with self.subTest():
+                self.assertEqual(_parse_reference_genome(i), "grch37.p10")
+
     def test_ref_genome_values_38(self):
         """
         Check valid synonyms for GRCh38 are converted
@@ -29,20 +38,28 @@ class TestParsingRefGenome(TestCase):
             with self.subTest():
                 self.assertEqual(_parse_reference_genome(i), "GRCh38")
 
+    def test_ref_genome_values_37_with_patch(self):
+        """
+        Check valid synonyms for GRCh37 are converted
+        """
+        valid = ["GRCh38.p10", "Grch38.p10"]
+        for i in valid:
+            with self.subTest():
+                self.assertEqual(_parse_reference_genome(i), "grch38.p10")
+
     def test_invalid_ref_genomes(self):
         """
         Check that nonsense strings throw a ValueError and a handy message
         """
-        invalid = ["1234", "beans", "£&£*$"]
+        invalid = ["1234", "beans", "£&£*$", "hg19.p10", "GRCh38.p12not_a_real_patch"]
 
         permitted_grch37 = ["hg19", "37", "grch37"]
         permitted_grch38 = ["hg38", "38", "grch38"]
 
         for i in invalid:
             with self.subTest():
-                msg = "Please provide a valid reference genome,"
-                f" such as {'; '.join(permitted_grch37)} or "
-                f"{'; '.join(permitted_grch38)} - you provided {i}"
-
-                with self.assertRaisesRegex(ValueError, msg):
+                msg = f"Please provide a valid reference genome, such as {'; '.join(permitted_grch37)}, "
+                f"{'; '.join(permitted_grch38)} or GRCh37/GRCh38 followed by '.p' patch numbers - you provided {i}"
+                with self.assertRaises(ValueError) as cm:
                     _parse_reference_genome(i)
+                    self.assertEqual(msg, cm.exception)

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_reference_genome.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_reference_genome.py
@@ -51,7 +51,7 @@ class TestParsingRefGenome(TestCase):
         """
         Check that nonsense strings throw a ValueError and a handy message
         """
-        invalid = ["1234", "beans", "£&£*$", "hg19.p10", "GRCh38.p12not_a_real_patch"]
+        invalid = ["1234", "beans", "£&£*$", "hg19.p10", "GRCh37.p12not_a_real_patch", "GRCh38.p12not_a_real_patch"]
 
         permitted_grch37 = ["hg19", "37", "grch37"]
         permitted_grch38 = ["hg38", "38", "grch38"]


### PR DESCRIPTION
panels_backend is currently set up to only accept ‘GRCh37’ and ‘GRCh38’ at the CLI (or synonyms ‘hg19’ and ‘hg38’, or varied-case versions thereof). However, variant_db often requires specific patches such as ‘GRCh37.p13’ to be named.

Minor changes were made to ensure that panels_backend accepts patch numbers in reference genome names at the CLI (see function ‘_parse_reference_genome’). Tests were changed appropriately.


Ran 138 tests in 4.085s

OK

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/83)
<!-- Reviewable:end -->
