### PR TITLE
In 432 specify gff at g2t output

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ python manage.py generate g2t --ref_genome <ref_genome> --gff_release <gff_relea
 ```
 To run with a specified output pathway:
 ```
-python manage.py generate g2t --ref_genome <ref_genome> --output <output pathway>
+python manage.py generate g2t --ref_genome <ref_genome> --gff_release <gff_release> --output <output pathway>
 ```
 
 ### Edit links between panel-related tables

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ python manage.py seed transcript \
 --error
 
 # working example
-python manage.py seed transcript --hgnc testing_files/eris/hgnc_dump_20230613.txt --hgnc_release 1.0 --mane testing_files/eris/mane_grch37.csv --mane_ext_id file-123 --mane_release 1.0 --gff testing_files/eris/GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv --gff_release 1.0 --g2refseq testing_files/eris/gene2refseq_202306131409.csv --g2refseq_ext_id file-123 --markname testing_files/eris/markname_202306131409.csv --markname_ext_id file-234 --hgmd_release 1.4 --refgenome grch37
+python manage.py seed transcript --hgnc testing_files/eris/hgnc_dump_20230613.txt --hgnc_release 1.0 --mane testing_files/eris/mane_grch37.csv --mane_ext_id file-123 --mane_release 1.0 --gff testing_files/eris/GCF_000001405.25_GRCh37.p13_genomic.exon_5bp_v2.0.0.tsv --gff_release 19 --g2refseq testing_files/eris/gene2refseq_202306131409.csv --g2refseq_ext_id file-123 --markname testing_files/eris/markname_202306131409.csv --markname_ext_id file-234 --hgmd_release 1.4 --refgenome grch37
 ```
 
 The arguments are as follows:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The arguments for this command are:
 
 #### 3. Seed transcript
 
-Adds transcripts to the database, for either GRCh37 or GRCh38. The possible transcripts are provided in a GFF file.
+Adds transcripts to the database, for either GRCh37 or GRCh38. The possible transcripts are provided in a GFF file. Note that if you use VEP in your pipelines, you should ensure you provide the file compatible with your current version of VEP.
 
 MANE and HGMD files are used to assign transcripts as being the 'default' clinical or non-clinical for each gene. The MANE file for GRCh37 is a CSV file downloaded from Transcript Archive http://tark.ensembl.org/web/mane_GRCh37_list/) and the HGMD files are CSV files of the 'markname' and 'g2refseq' tables, generated when the HGMD database is dumped.  
 
@@ -154,7 +154,7 @@ The arguments are as follows:
 - `mane_ext_id`: the external file ID for the release-tagged MANE CSV file
 - `mane_release`: the release version associated with the MANE CSV file and its file ID. This must consist only of numbers and full stops, e.g. 1.0.1.
 - `gff`: path to parsed gff.tsv (project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gk7gZ47gypK7ZZ)
-- `gff_release`: the documented release version for the `gff` file. This must consist only of numbers and full stops, e.g. 1.0.1.
+- `gff_release`: the documented release version for the `gff` file you are providing for transcript annotations. This must consist only of numbers and full stops. It is recommended that you use the GENCODE release, and if you use VEP in your pipeline, you should select a release compatible with your currently-used VEP version.
 - `g2refseq`: path to the g2refseq table from the HGMD database, in csv format
 - `g2refseq_ext_id`: external file ID for release-tagged HGMD g2refseq table
 - `markname`: path to markname table from the HGMD database, in csv format
@@ -196,7 +196,12 @@ Provide the reference genome as a string input. GRCh37 and GRCh38 are the curren
 
 To run generate g2t without a specified output pathway (note that this will create the file in your current working directory):
 ```
-python manage.py generate g2t --ref_genome <ref_genome>
+python manage.py generate g2t --ref_genome <ref_genome> --gff_release <gff_release>
+
+- `ref_genome`: the name of your reference genome build. Currently permitted values are: 37/GRCh37/hg19 or 38/GRCh38/hg38
+
+- `gff_release`: the documented release version for the `gff` file you are providing for transcript annotations. This must consist only of numbers and full stops. It is recommended that you use a GENCODE release version which is compatible with your chosen reference genome. If you use VEP in your pipeline, you should select a release compatible with your currently-used VEP version. 
+
 ```
 To run with a specified output pathway:
 ```

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The arguments are as follows:
 - `mane_ext_id`: the external file ID for the release-tagged MANE CSV file
 - `mane_release`: the release version associated with the MANE CSV file and its file ID. This must consist only of numbers and full stops, e.g. 1.0.1.
 - `gff`: path to parsed gff.tsv (project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gk7gZ47gypK7ZZ)
-- `gff_release`: the documented release version for the `gff` file you are providing for transcript annotations. This must consist only of numbers and full stops. It is recommended that you use the GENCODE release, and if you use VEP in your pipeline, you should select a release compatible with your currently-used VEP version.
+- `gff_release`: the documented release version for the `gff` file you are providing for transcript annotations. This must consist only of numbers and full stops. It is recommended that you use the Ensembl release, and if you use VEP in your pipeline, you should select a release compatible with your currently-used VEP version.
 - `g2refseq`: path to the g2refseq table from the HGMD database, in csv format
 - `g2refseq_ext_id`: external file ID for release-tagged HGMD g2refseq table
 - `markname`: path to markname table from the HGMD database, in csv format
@@ -200,7 +200,7 @@ python manage.py generate g2t --ref_genome <ref_genome> --gff_release <gff_relea
 
 - `ref_genome`: the name of your reference genome build. Currently permitted values are: 37/GRCh37/hg19 or 38/GRCh38/hg38
 
-- `gff_release`: the documented release version for the `gff` file you are providing for transcript annotations. This must consist only of numbers and full stops. It is recommended that you use a GENCODE release version which is compatible with your chosen reference genome. If you use VEP in your pipeline, you should select a release compatible with your currently-used VEP version. 
+- `gff_release`: the documented release version for the `gff` file you are providing for transcript annotations. This must consist only of numbers and full stops. It is recommended that you use an Ensembl release version which is compatible with your chosen reference genome. If you use VEP in your pipeline, you should select a release compatible with your currently-used VEP version. 
 
 ```
 To run with a specified output pathway:

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -761,10 +761,10 @@ def _transcript_assign_to_source(
     relevant_panels = PanelGene.objects.filter(gene__hgnc_id=hgnc_id)
 
     if mane_exact_match:
-        error, error_msg = _check_for_more_than_one_tx_match(
+        multiple_matches, error_msg = _check_for_more_than_one_tx_match(
             mane_exact_match, relevant_panels, tx
         )
-        if error:
+        if multiple_matches:
             return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
         else:
             # determine whether it's MANE Select or Plus Clinical and return everything
@@ -779,10 +779,10 @@ def _transcript_assign_to_source(
 
     # fall through to here if no exact match - see if there's a versionless match instead
     elif mane_base_match:
-        error, error_msg = _check_for_more_than_one_tx_match(
+        multiple_matches, error_msg = _check_for_more_than_one_tx_match(
             mane_base_match, relevant_panels, tx
         )
-        if error:
+        if multiple_matches:
             return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
         else:
             source = mane_base_match[0]["MANE TYPE"]

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -677,9 +677,9 @@ def _check_for_more_than_one_tx_match(matches, relevant_panels, tx) -> tuple[boo
         return False, None
 
 
-def _assign_mane_dicts_by_type(source: str, mane_select_data: dict(str, str),
-                   mane_plus_clinical_data: dict(str, str), does_version_match: bool)\
-                    -> tuple[dict(str, str), dict(str, str)]:
+def _assign_mane_dicts_by_type(source: str, mane_select_data: dict[str, str],
+                   mane_plus_clinical_data: dict[str, str], does_version_match: bool)\
+                    -> tuple[dict[str, str], dict[str, str]]:
     """
     Work out whether a MANE transcript is Select or Plus Clinical.
     Assigns it to the correct dictionary accordinly.

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -818,7 +818,7 @@ def _add_gff_release_info_to_db(
     :return gff_release: a GffRelease instance
     """
     gff_release, _ = GffRelease.objects.get_or_create(
-        gencode_release=gff_release, reference_genome=reference_genome
+        ensembl_release=gff_release, reference_genome=reference_genome
     )
     return gff_release
 
@@ -974,9 +974,9 @@ def _get_latest_gff_release(ref_genome: ReferenceGenome) -> GffRelease | None:
     """
     gffs = GffRelease.objects.filter(reference_genome=ref_genome)
 
-    max_release = max([Version(v.gencode_release) for v in gffs]) if gffs else None
+    max_release = max([Version(v.ensembl_release) for v in gffs]) if gffs else None
     if max_release:
-        return GffRelease.objects.get(gencode_release=max_release)
+        return GffRelease.objects.get(ensembl_release=max_release)
     else:
         return None
 
@@ -1059,7 +1059,7 @@ def _check_for_transcript_seeding_version_regression(
         latest_hgnc_release = None
 
     if _get_latest_gff_release(reference_genome):
-        latest_gff_release = _get_latest_gff_release(reference_genome).gencode_release
+        latest_gff_release = _get_latest_gff_release(reference_genome).ensembl_release
     else:
         latest_gff_release = None
 

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -926,7 +926,7 @@ def _get_latest_gff_release(ref_genome: ReferenceGenome) -> GffRelease | None:
     """
     gffs = GffRelease.objects.filter(reference_genome=ref_genome)
 
-    max_release = max([Version(v.release) for v in gffs]) if gffs else None
+    max_release = max([Version(v.gencode_release) for v in gffs]) if gffs else None
     if max_release:
         return GffRelease.objects.get(gencode_release=max_release)
     else:
@@ -1011,7 +1011,7 @@ def _check_for_transcript_seeding_version_regression(
         latest_hgnc_release = None
 
     if _get_latest_gff_release(reference_genome):
-        latest_gff_release = _get_latest_gff_release(reference_genome).release
+        latest_gff_release = _get_latest_gff_release(reference_genome).gencode_release
     else:
         latest_gff_release = None
 

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -778,7 +778,7 @@ def _add_gff_release_info_to_db(
     :return gff_release: a GffRelease instance
     """
     gff_release, _ = GffRelease.objects.get_or_create(
-        release=gff_release, reference_genome=reference_genome
+        gencode_release=gff_release, reference_genome=reference_genome
     )
     return gff_release
 
@@ -928,7 +928,7 @@ def _get_latest_gff_release(ref_genome: ReferenceGenome) -> GffRelease | None:
 
     max_release = max([Version(v.release) for v in gffs]) if gffs else None
     if max_release:
-        return GffRelease.objects.get(release=max_release)
+        return GffRelease.objects.get(gencode_release=max_release)
     else:
         return None
 

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -768,15 +768,18 @@ def _transcript_assign_to_source(
         (
             multiple_matches,
             error_msg,
-        ) = _check_for_more_than_one_tx_match_in_panel_linked_tx(transcript_list, tx)
+        ) = _check_for_more_than_one_tx_match_in_panel_linked_tx(
+            transcript_list, hgnc_id, tx
+        )
+
         if not multiple_matches:
             mane_info, mane_type = _populate_mane_dict_by_category(
                 transcript_list,
                 does_version_match,
             )
-            if mane_type == "mane select":
+            if mane_type.lower() == "mane select":
                 mane_select_data = mane_info
-            elif mane_type == "mane plus clinical":
+            elif mane_type.lower() == "mane plus clinical":
                 mane_plus_clinical_data = mane_info
         # if there are multiple matches in IRRELEVANT transcripts it'll return blank dictionaries and an error msg
         return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg

--- a/panels_backend/management/commands/_parse_transcript.py
+++ b/panels_backend/management/commands/_parse_transcript.py
@@ -764,9 +764,7 @@ def _transcript_assign_to_source(
         multiple_matches, error_msg = _check_for_more_than_one_tx_match(
             mane_exact_match, relevant_panels, tx
         )
-        if multiple_matches:
-            return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
-        else:
+        if not multiple_matches:
             # determine whether it's MANE Select or Plus Clinical and return everything
             source = mane_exact_match[0]["MANE TYPE"]
             mane_select_data, mane_plus_clinical_data = _populate_mane_dict_by_category(
@@ -775,16 +773,15 @@ def _transcript_assign_to_source(
                 mane_plus_clinical_data,
                 does_version_match=True,
             )
-            return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
+        # if there are multiple matches in IRRELEVANT transcripts it'll return blank dictionaries and an error msg
+        return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
 
     # fall through to here if no exact match - see if there's a versionless match instead
     elif mane_base_match:
         multiple_matches, error_msg = _check_for_more_than_one_tx_match(
             mane_base_match, relevant_panels, tx
         )
-        if multiple_matches:
-            return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
-        else:
+        if not multiple_matches:
             source = mane_base_match[0]["MANE TYPE"]
             mane_select_data, mane_plus_clinical_data = _populate_mane_dict_by_category(
                 source,
@@ -792,7 +789,8 @@ def _transcript_assign_to_source(
                 mane_plus_clinical_data,
                 does_version_match=False,
             )
-            return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
+        # if there are multiple matches in IRRELEVANT transcripts it'll return blank dictionaries and an error msg
+        return mane_select_data, mane_plus_clinical_data, hgmd_data, error_msg
 
     # transcript's gene is not in MANE - so look in HGMD
     # note HGMD doesn't contain versions so we must match just against accession

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -417,7 +417,7 @@ class Command(BaseCommand):
                     clinical = True
             return clinical
 
-    def _generate_g2t_results(self, ref_genome, gff_release) -> list[dict(str, str)]:
+    def _generate_g2t_results(self, ref_genome: ReferenceGenome, gff_release: GffRelease) -> list[dict[str, str]]:
         """
         Main function to generate g2t.tsv
         Calls the function to get all current transcripts, then formats it, ready to write to file.
@@ -427,6 +427,7 @@ class Command(BaseCommand):
         :param ref_genome: ReferenceGenome instance
         :param gff_release: GffRelease instance. This will be a GFF release which is appropriate for
         the stated ReferenceGenome.
+        :return: a list-of-dictionaries - each dict can be used to write out a line
         """
         start = dt.datetime.now().strftime("%H:%M:%S")
         print(f"Creating g2t file for reference genome {ref_genome.name} at {start}")
@@ -472,7 +473,7 @@ class Command(BaseCommand):
         return results
 
     def _write_g2t_results(
-        self, results: list[dict(str, str)], output_directory: str
+        self, results: list[dict[str, str]], output_directory: str
     ) -> None:
         """
         Writes out g2t results to a TSV file at the specified output directory.
@@ -594,7 +595,7 @@ class Command(BaseCommand):
                     "Aborting g2t: GFF release does not exist for this genome build in the database."
                 )
 
-            g2t = self._generate_g2t_results(output_directory, genome, gff_release)
+            g2t = self._generate_g2t_results(genome, gff_release)
             self._write_g2t_results(g2t, output_directory)
 
             end = dt.datetime.now().strftime("%H:%M:%S")

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -265,8 +265,6 @@ class Command(BaseCommand):
                 panelapp_id: str = panel_dict.get(
                     "ci_superpanel__superpanel__external_id", ""
                 )
-                if not panelapp_id:
-                    panelapp_id = ""
                 ci_name: str = panel_dict["ci_superpanel__clinical_indication__name"]
 
                 for hgnc in panel_genes[panel_id]:
@@ -417,7 +415,9 @@ class Command(BaseCommand):
                     clinical = True
             return clinical
 
-    def _generate_g2t_results(self, ref_genome: ReferenceGenome, gff_release: GffRelease) -> list[dict[str, str]]:
+    def _generate_g2t_results(
+        self, ref_genome: ReferenceGenome, gff_release: GffRelease
+    ) -> list[dict[str, str]]:
         """
         Main function to generate g2t.tsv
         Calls the function to get all current transcripts, then formats it, ready to write to file.

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -442,7 +442,7 @@ class Command(BaseCommand):
 
         # We only need to assess those transcripts which are linked to the correct GFF release and reference genome
         gff_transcripts = TranscriptGffRelease.objects.filter(
-            gff_release__gencode_release=gff_release,
+            gff_release__ensembl_release=gff_release,
             gff_release__reference_genome=ref_genome,
         )
 
@@ -583,7 +583,7 @@ class Command(BaseCommand):
 
             try:
                 gff_release = GffRelease.objects.get(
-                    gencode_release=kwargs.get("gff_release"), reference_genome=genome
+                    ensembl_release=kwargs.get("gff_release"), reference_genome=genome
                 )
             except ObjectDoesNotExist:
                 raise ObjectDoesNotExist(

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -455,8 +455,9 @@ class Command(BaseCommand):
             results.append(transcript_data)
         return results
 
-
-    def _write_g2t_results(self, results: list[dict(str, str)], output_directory: str) -> None:
+    def _write_g2t_results(
+        self, results: list[dict(str, str)], output_directory: str
+    ) -> None:
         """
         Writes out g2t results to a TSV file at the specified output directory.
 
@@ -473,7 +474,6 @@ class Command(BaseCommand):
                 out_file, delimiter="\t", lineterminator="\n", fieldnames=keys
             )
             writer.writerows(results)
-
 
     def add_arguments(self, parser) -> None:
         """

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -450,15 +450,17 @@ class Command(BaseCommand):
         results = []
 
         for gff_tx in gff_transcripts:
+            # For each Transcript linked to this GFF release - make a row-dictionary of its data
+            tx = gff_tx.transcript
             clinical_status = self.get_current_transcript_clinical_status_for_g2t(
-                gff_tx.transcript, latest_select, latest_plus_clinical, latest_hgmd
+                tx, latest_select, latest_plus_clinical, latest_hgmd
             )
             displayable_clinical_status = (
                 "clinical_transcript" if clinical_status else "not_clinical_transcript"
             )
             transcript_data = {
-                "hgnc_id": gff_tx.transcript.gene.hgnc_id,
-                "transcript": gff_tx.transcript,
+                "hgnc_id": tx.gene.hgnc_id,
+                "transcript": tx,
                 "clinical": displayable_clinical_status,
             }
             results.append(transcript_data)

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -416,7 +416,8 @@ class Command(BaseCommand):
         
         :param output_directory: output directory
         :param ref_genome: ReferenceGenome instance
-        :param gff_release: GffRelease instance. This will be a GFF release which is appropriate for ReferenceGenome.
+        :param gff_release: GffRelease instance. This will be a GFF release which is appropriate for
+        the stated ReferenceGenome.
         """
         start = dt.datetime.now().strftime("%H:%M:%S")
         print(f"Creating g2t file for reference genome {ref_genome.name} at {start}")
@@ -436,7 +437,7 @@ class Command(BaseCommand):
 
         # We only need to assess those transcripts which are linked to the correct GFF release and reference genome
         gff_transcripts = TranscriptGffRelease.objects.filter(
-            gff_release__release=gff_release,
+            gff_release__gencode_release=gff_release,
             gff_release__reference_genome=ref_genome
         )
 
@@ -560,7 +561,8 @@ class Command(BaseCommand):
                 )
 
             try:
-                gff_release = GffRelease.objects.get(release=kwargs.get("gff_release"), reference_genome=genome)
+                gff_release = GffRelease.objects.get(gencode_release=kwargs.get("gff_release"),
+                                                     reference_genome=genome)
             except ObjectDoesNotExist:
                 raise ObjectDoesNotExist(
                     "Aborting g2t: GFF release does not exist for this genome build in the database."

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -449,16 +449,16 @@ class Command(BaseCommand):
         # Append per-transcript results to a list-of-dictionaries
         results = []
 
-        for transcript in gff_transcripts:
+        for gff_tx in gff_transcripts:
             clinical_status = self.get_current_transcript_clinical_status_for_g2t(
-                transcript.transcript, latest_select, latest_plus_clinical, latest_hgmd
+                gff_tx.transcript, latest_select, latest_plus_clinical, latest_hgmd
             )
             displayable_clinical_status = (
                 "clinical_transcript" if clinical_status else "not_clinical_transcript"
             )
             transcript_data = {
-                "hgnc_id": transcript.transcript.gene.hgnc_id,
-                "transcript": transcript.transcript,
+                "hgnc_id": gff_tx.transcript.gene.hgnc_id,
+                "transcript": gff_tx.transcript,
                 "clinical": displayable_clinical_status,
             }
             results.append(transcript_data)

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -541,14 +541,14 @@ class Command(BaseCommand):
             # get the reference genome and standardise it
             if not kwargs["ref_genome"]:
                 raise ValueError(
-                    "No reference genome specified, e.g. python manage.py generate g2t --ref_genome GRCh37 --gff_version <>"
+                    "No reference genome specified, e.g. python manage.py generate g2t --ref_genome GRCh37 --gff_release <>"
                 )
             parsed_genome = _parse_reference_genome(kwargs.get("ref_genome"))
 
             # get the GFF file release
             if not kwargs["gff_release"]:
                 raise ValueError(
-                    "No GFF version specified, e.g. python manage.py generate g2t --ref_genome GRCh37 --gff_version <>"
+                    "No GFF release specified, e.g. python manage.py generate g2t --ref_genome GRCh37 --gff_release <>"
                 )
             
             # if the genome AND gff_release are valid, run the controller function, _generate_g2t
@@ -560,7 +560,7 @@ class Command(BaseCommand):
                 )
 
             try:
-                gff_release = GffRelease.objects.get(release=kwargs.get("gff_version"), reference_genome=genome)
+                gff_release = GffRelease.objects.get(release=kwargs.get("gff_release"), reference_genome=genome)
             except ObjectDoesNotExist:
                 raise ObjectDoesNotExist(
                     "Aborting g2t: GFF release does not exist for this genome build in the database."

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -456,9 +456,6 @@ class Command(BaseCommand):
             displayable_clinical_status = (
                 "clinical_transcript" if clinical_status else "not_clinical_transcript"
             )
-            displayable_clinical_status = (
-                "clinical_transcript" if clinical_status else "not_clinical_transcript"
-            )
             transcript_data = {
                 "hgnc_id": transcript.transcript.gene.hgnc_id,
                 "transcript": transcript.transcript,

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -553,14 +553,14 @@ class Command(BaseCommand):
             
             # if the genome AND gff_release are valid, run the controller function, _generate_g2t
             try:
-                genome = ReferenceGenome.objects.get(reference_genome=parsed_genome)
+                genome = ReferenceGenome.objects.get(name=parsed_genome)
             except ObjectDoesNotExist:
                 raise ObjectDoesNotExist(
                     "Aborting g2t: reference genome does not exist in the database"
                 )
 
             try:
-                gff_release = GffRelease.objects.get(release=kwargs.get("gff_release"), reference_genome=genome)
+                gff_release = GffRelease.objects.get(release=kwargs.get("gff_version"), reference_genome=genome)
             except ObjectDoesNotExist:
                 raise ObjectDoesNotExist(
                     "Aborting g2t: GFF release does not exist for this genome build in the database."

--- a/panels_backend/management/commands/generate.py
+++ b/panels_backend/management/commands/generate.py
@@ -14,7 +14,7 @@ from panels_backend.models import (
     TestDirectoryRelease,
     ReferenceGenome,
     GffRelease,
-    TranscriptGffRelease
+    TranscriptGffRelease,
 )
 import os
 import csv
@@ -413,7 +413,7 @@ class Command(BaseCommand):
         Calls the function to get all current transcripts, then formats and writes it to file.
         Returned transcripts are limited to those represented in the user-requested reference genome
         and GFF release.
-        
+
         :param output_directory: output directory
         :param ref_genome: ReferenceGenome instance
         :param gff_release: GffRelease instance. This will be a GFF release which is appropriate for
@@ -438,7 +438,7 @@ class Command(BaseCommand):
         # We only need to assess those transcripts which are linked to the correct GFF release and reference genome
         gff_transcripts = TranscriptGffRelease.objects.filter(
             gff_release__gencode_release=gff_release,
-            gff_release__reference_genome=ref_genome
+            gff_release__reference_genome=ref_genome,
         )
 
         # Append per-transcript results to a list-of-dictionaries
@@ -551,7 +551,7 @@ class Command(BaseCommand):
                 raise ValueError(
                     "No GFF release specified, e.g. python manage.py generate g2t --ref_genome GRCh37 --gff_release <>"
                 )
-            
+
             # if the genome AND gff_release are valid, run the controller function, _generate_g2t
             try:
                 genome = ReferenceGenome.objects.get(name=parsed_genome)
@@ -561,8 +561,9 @@ class Command(BaseCommand):
                 )
 
             try:
-                gff_release = GffRelease.objects.get(gencode_release=kwargs.get("gff_release"),
-                                                     reference_genome=genome)
+                gff_release = GffRelease.objects.get(
+                    gencode_release=kwargs.get("gff_release"), reference_genome=genome
+                )
             except ObjectDoesNotExist:
                 raise ObjectDoesNotExist(
                     "Aborting g2t: GFF release does not exist for this genome build in the database."

--- a/panels_backend/management/commands/seed.py
+++ b/panels_backend/management/commands/seed.py
@@ -64,7 +64,10 @@ class Command(BaseCommand):
     def _validate_release_versions(self, releases: list[str]) -> None:
         """
         Validate that the external releases are in the correct format
-        Only numbers and dots are permitted, e.g. 1.0.13
+        Only numbers on their own (e.g. 3) and numbers with dots (e.g. 1.0.13) are permitted
+        Raises error if anything else is encountered
+
+        :param: list of releases provided at CLI
         """
 
         invalid_releases = [id for id in releases if not re.match(r"^\d+(\.\d+)*$", id)]
@@ -76,7 +79,9 @@ class Command(BaseCommand):
             )
 
     def add_arguments(self, parser) -> None:
-        """Define the source of the data to import."""
+        """
+        Define the source of the data to import.
+        """
 
         # python manage.py seed --debug panelapp all
         parser.add_argument("--debug", action="store_true", help="debug mode")

--- a/panels_backend/management/commands/seed.py
+++ b/panels_backend/management/commands/seed.py
@@ -312,7 +312,7 @@ class Command(BaseCommand):
             4. MANE file's external ID (e.g. in DNAnexus)
             5. MANE release version
             6. parsed gff file on DNAnexus (project-Fkb6Gkj433GVVvj73J7x8KbV:file-GF611Z8433Gk7gZ47gypK7ZZ)
-            7. gff release - the in-house release version assigned to the GFF file
+            7. gff release - the release version assigned to the GFF file.
             8. gene2refseq table from HGMD database
             9. gene2refseq table's external ID
             10. markname table from HGMD database

--- a/panels_backend/models.py
+++ b/panels_backend/models.py
@@ -874,11 +874,11 @@ class GffRelease(models.Model):
     """
     Defines a particular release of the GFF file, the source of possibly-clinically relevant
     transcripts. Release versions must be unique for a given reference genome.
-    Currently, the GENCODE release number is used.
+    Currently, the Ensembl release number is used.
     """
 
-    gencode_release = models.TextField(
-        verbose_name="Gff Release in GENCODE", unique=True
+    ensembl_release = models.TextField(
+        verbose_name="Gff Release in Ensembl versioning system", unique=True
     )
 
     reference_genome = models.ForeignKey(
@@ -895,7 +895,7 @@ class GffRelease(models.Model):
 
     class Meta:
         db_table = "gff_release"
-        unique_together = ["gencode_release", "reference_genome"]
+        unique_together = ["ensembl_release", "reference_genome"]
 
     def __str__(self):
         return str(self.id)

--- a/panels_backend/models.py
+++ b/panels_backend/models.py
@@ -893,7 +893,7 @@ class GffRelease(models.Model):
 
     class Meta:
         db_table = "gff_release"
-        unique_together = ["release", "reference_genome"]
+        unique_together = ["gencode_release", "reference_genome"]
 
     def __str__(self):
         return str(self.id)

--- a/panels_backend/models.py
+++ b/panels_backend/models.py
@@ -877,7 +877,9 @@ class GffRelease(models.Model):
     Currently, the GENCODE release number is used.
     """
 
-    gencode_release = models.TextField(verbose_name="Gff Release in GENCODE", unique=True)
+    gencode_release = models.TextField(
+        verbose_name="Gff Release in GENCODE", unique=True
+    )
 
     reference_genome = models.ForeignKey(
         ReferenceGenome,

--- a/panels_backend/models.py
+++ b/panels_backend/models.py
@@ -877,6 +877,7 @@ class GffRelease(models.Model):
     The Ensembl release version is used (rather than e.g. GENCODE).
     Release version must be unique for a given reference genome.
     """
+
     ensembl_release = models.TextField(
         verbose_name="Gff Release in Ensembl versioning system", unique=True
     )

--- a/panels_backend/models.py
+++ b/panels_backend/models.py
@@ -872,11 +872,11 @@ class TranscriptReleaseTranscript(models.Model):
 
 class GffRelease(models.Model):
     """
-    Defines a particular release of the GFF file, the source of possibly-clinically relevant
-    transcripts. Release versions must be unique for a given reference genome.
-    Currently, the Ensembl release number is used.
+    Defines a particular release of the GFF file,
+    which acts as the source of possibly-clinically relevant transcripts.
+    The Ensembl release version is used (rather than e.g. GENCODE).
+    Release version must be unique for a given reference genome.
     """
-
     ensembl_release = models.TextField(
         verbose_name="Gff Release in Ensembl versioning system", unique=True
     )

--- a/panels_backend/models.py
+++ b/panels_backend/models.py
@@ -874,9 +874,10 @@ class GffRelease(models.Model):
     """
     Defines a particular release of the GFF file, the source of possibly-clinically relevant
     transcripts. Release versions must be unique for a given reference genome.
+    Currently, the GENCODE release number is used.
     """
 
-    release = models.TextField(verbose_name="Gff Release", unique=True)
+    gencode_release = models.TextField(verbose_name="Gff Release in GENCODE", unique=True)
 
     reference_genome = models.ForeignKey(
         ReferenceGenome,

--- a/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genepanels.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genepanels.py
@@ -48,6 +48,50 @@ class TestFormatOutputDataGenepanels(TestCase):
         ]
         self.assertEqual(expected, actual)
 
+    def test_unversioned_panel(self):
+        """
+        CASE: As basic case, but one panel doesn't have a version (probably because it's custom).
+        EXPECT: Return a 4-entry list-of-lists which captures the CI's R code/name, the panel's name and version,
+        the HGNC, and the PanelApp version on each line. For the versionless panel, the version will
+        be a BLANK STRING, ""
+        """
+        ci_panels = {
+            "R123.2": [
+                {
+                    "ci_panel__clinical_indication__r_code": "R1",
+                    "ci_panel__clinical_indication_id__name": "Condition 1",
+                    "ci_panel__panel_id": 1,
+                    "ci_panel__panel__external_id": "109",
+                    "ci_panel__panel__panel_name": "First Panel",
+                    "ci_panel__panel__panel_version": None,
+                }
+            ],
+            "R2": [
+                {
+                    "ci_panel__clinical_indication__r_code": "R2",
+                    "ci_panel__clinical_indication_id__name": "Condition 2",
+                    "ci_panel__panel_id": 2,
+                    "ci_panel__panel__external_id": "209",
+                    "ci_panel__panel__panel_name": "Second Panel",
+                    "ci_panel__panel__panel_version": "2",
+                }
+            ],
+        }
+
+        panel_genes = {1: ["HGNC:1", "HGNC:2"], 2: ["HGNC:3", "HGNC:4"]}
+        excluded_hgncs = set([])
+        cmd = Command()
+        actual = cmd._format_output_data_genepanels(
+            ci_panels, panel_genes, excluded_hgncs
+        )
+        expected = [
+            ["R123.2_Condition 1", "First Panel_", "HGNC:1", "109"],
+            ["R123.2_Condition 1", "First Panel_", "HGNC:2", "109"],
+            ["R2_Condition 2", "Second Panel_2", "HGNC:3", "209"],
+            ["R2_Condition 2", "Second Panel_2", "HGNC:4", "209"],
+        ]
+        self.assertEqual(expected, actual)
+
     def test_includes_non_panelapp_panel(self):
         """
         CASE: Two Clinical Indications are provided with links to 1 panel each. Each panel contains 2 genes.

--- a/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
@@ -102,4 +102,3 @@ class TestFormatGeneSuperPanels(TestCase):
         )
 
         self.assertEqual(expected, actual)
-

--- a/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
@@ -102,3 +102,4 @@ class TestFormatGeneSuperPanels(TestCase):
         )
 
         self.assertEqual(expected, actual)
+

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -34,7 +34,7 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
         self.ref_genome, _ = ReferenceGenome.objects.get_or_create(name="GRCh37")
 
         self.gff_release, _ = GffRelease.objects.get_or_create(
-            release="v10.2", reference_genome=self.ref_genome
+            gencode_release="10", reference_genome=self.ref_genome
         )
 
         self.user = "init_v1_user"
@@ -101,7 +101,7 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
         self.ref_genome, _ = ReferenceGenome.objects.get_or_create(name="GRCh37")
 
         self.gff_release, _ = GffRelease.objects.get_or_create(
-            release="v10.2", reference_genome=self.ref_genome
+            gencode_release="10.2", reference_genome=self.ref_genome
         )
 
         self.transcript, _ = Transcript.objects.get_or_create(

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -63,7 +63,7 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
 
         release = GffRelease.objects.all()
         err += len_check_wrapper(release, "releases", 1)
-        err += value_check_wrapper(release[0].release, "release version", "v10.2")
+        err += value_check_wrapper(release[0].gencode_release, "release version", "10")
 
         tx_release = TranscriptGffRelease.objects.all()
         err += len_check_wrapper(tx_release, "tx-release links", 1)
@@ -136,7 +136,7 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
 
         release = GffRelease.objects.all()
         err += len_check_wrapper(release, "releases", 1)
-        err += value_check_wrapper(release[0].release, "release version", "v10.2")
+        err += value_check_wrapper(release[0].gencode_release, "release version", "10.2")
 
         tx_release = TranscriptGffRelease.objects.all()
         err += len_check_wrapper(tx_release, "tx-release links", 1)

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -136,7 +136,9 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
 
         release = GffRelease.objects.all()
         err += len_check_wrapper(release, "releases", 1)
-        err += value_check_wrapper(release[0].gencode_release, "release version", "10.2")
+        err += value_check_wrapper(
+            release[0].gencode_release, "release version", "10.2"
+        )
 
         tx_release = TranscriptGffRelease.objects.all()
         err += len_check_wrapper(tx_release, "tx-release links", 1)

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_add_transcript_to_db_with_gff_release.py
@@ -34,7 +34,7 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
         self.ref_genome, _ = ReferenceGenome.objects.get_or_create(name="GRCh37")
 
         self.gff_release, _ = GffRelease.objects.get_or_create(
-            gencode_release="10", reference_genome=self.ref_genome
+            ensembl_release="10", reference_genome=self.ref_genome
         )
 
         self.user = "init_v1_user"
@@ -63,7 +63,7 @@ class TestAddTranscriptWithGff_NewTranscript(TestCase):
 
         release = GffRelease.objects.all()
         err += len_check_wrapper(release, "releases", 1)
-        err += value_check_wrapper(release[0].gencode_release, "release version", "10")
+        err += value_check_wrapper(release[0].ensembl_release, "release version", "10")
 
         tx_release = TranscriptGffRelease.objects.all()
         err += len_check_wrapper(tx_release, "tx-release links", 1)
@@ -101,7 +101,7 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
         self.ref_genome, _ = ReferenceGenome.objects.get_or_create(name="GRCh37")
 
         self.gff_release, _ = GffRelease.objects.get_or_create(
-            gencode_release="10.2", reference_genome=self.ref_genome
+            ensembl_release="10.2", reference_genome=self.ref_genome
         )
 
         self.transcript, _ = Transcript.objects.get_or_create(
@@ -137,7 +137,7 @@ class TestAddTranscriptWithGff_ExistingTranscripts(TestCase):
         release = GffRelease.objects.all()
         err += len_check_wrapper(release, "releases", 1)
         err += value_check_wrapper(
-            release[0].gencode_release, "release version", "10.2"
+            release[0].ensembl_release, "release version", "10.2"
         )
 
         tx_release = TranscriptGffRelease.objects.all()

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
@@ -32,10 +32,10 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
         # pre-populate releases
         self.hgnc = HgncRelease.objects.create(release="2")
         self.gff = GffRelease.objects.create(
-            gencode_release="10", reference_genome=self.reference_genome
+            ensembl_release="10", reference_genome=self.reference_genome
         )
         self.gff_2 = GffRelease.objects.create(
-            gencode_release="5", reference_genome=self.reference_genome
+            ensembl_release="5", reference_genome=self.reference_genome
         )
         self.mane_select = TranscriptRelease.objects.create(
             release="2",

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
@@ -32,10 +32,10 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
         # pre-populate releases
         self.hgnc = HgncRelease.objects.create(release="2")
         self.gff = GffRelease.objects.create(
-            release="1.0", reference_genome=self.reference_genome
+            gencode_release="10", reference_genome=self.reference_genome
         )
         self.gff_2 = GffRelease.objects.create(
-            release="0.5", reference_genome=self.reference_genome
+            gencode_release="5", reference_genome=self.reference_genome
         )
         self.mane_select = TranscriptRelease.objects.create(
             release="2",

--- a/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_parse_transcript/test_check_for_transcript_seeding_version_regression.py
@@ -58,7 +58,7 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
         EXPECT: Exception raised with an error for the HGNC release
         """
         new_hgnc = "1"  # this one is higher
-        new_gff = "1.0"
+        new_gff = "10"
         new_mane = "2"
         new_hgmd = "2.1"
 
@@ -76,7 +76,7 @@ class TestCheckRegressions_OldHgncRelease(TestCase):
         EXPECT: Exception raised with an error for the affected releases only.
         """
         new_hgnc = "1"  # too old
-        new_gff = "1.0"
+        new_gff = "11"
         new_mane = "2"
         new_hgmd = "1.9.0"  # too old, uses subversioning
 


### PR DESCRIPTION
We need to make sure that when we output g2t files, that we only output transcripts which are compatible with the currently-used version of VEP. We would do this by ensuring that the correct GFF release is used.
Changes:
- In the README - add 'check that your version of the GFF is identical to that used by your pipeline's current version of VEP'
- generate.py: the user provides a GFF release at g2t generation time. Instead of defaulting to the latest GFF, Eris will use that release. If that release isn’t available, it will throw an error


Ran 138 tests in 4.457s

OK
Destroying test database for alias 'default'...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/84)
<!-- Reviewable:end -->
