### PR TITLE
In 470 unit test utils

### DIFF
--- a/panels_backend/management/commands/utils.py
+++ b/panels_backend/management/commands/utils.py
@@ -4,6 +4,8 @@ import pandas as pd
 def sortable_version(version: str) -> str:
     """
     Turn '1.1' -> '00001.00001'
+    Note you MUST provide a string not a number or behaviour gets weird
+    (e.g. if you provide 5.10 as a float, the final 0 gets dropped)
     """
     return ".".join(bit.zfill(5) for bit in str(version).split("."))
 

--- a/panels_backend/management/commands/utils.py
+++ b/panels_backend/management/commands/utils.py
@@ -10,14 +10,13 @@ def sortable_version(version: str) -> str:
     return ".".join(bit.zfill(5) for bit in str(version).split("."))
 
 
-def normalize_version(padded_version: str) -> str | float:
+def normalize_version(padded_version: str) -> str:
     """
     Turn '00001.00001' -> '1.1'
-    If no version is available this returns 0.0 as a float
-    Otherwise, you get a string.
+    If no version is available this returns '0.0'.
     """
     if not padded_version:
-        return 0.0
+        return "0.0"
 
     result = str(
         ".".join(bit.lstrip("0") for bit in padded_version.split("."))

--- a/panels_backend/management/commands/utils.py
+++ b/panels_backend/management/commands/utils.py
@@ -13,6 +13,8 @@ def sortable_version(version: str) -> str:
 def normalize_version(padded_version: str) -> str | float:
     """
     Turn '00001.00001' -> '1.1'
+    If no version is available this returns 0.0 as a float
+    Otherwise, you get a string.
     """
     if not padded_version:
         return 0.0

--- a/panels_backend/management/commands/utils.py
+++ b/panels_backend/management/commands/utils.py
@@ -17,10 +17,14 @@ def normalize_version(padded_version: str) -> str | float:
     if not padded_version:
         return 0.0
 
-    # TODO: fix issue where float conversion strips trailing 0s -
-    # e.g. 00005.00010 becomes 5.1 when it should be 5.10
-
-    return str(".".join(bit.lstrip("0") for bit in padded_version.split(".")))
+    result = str(
+        ".".join(bit.lstrip("0") for bit in padded_version.split("."))
+    )
+    if result.endswith("."):
+        # this stops cases where you get returned "5." instead of "5.0",
+        # when the db string is "00005.00000"
+        result = result + "0"
+    return result
 
 
 def parse_excluded_hgncs_from_file(file_path) -> set:

--- a/panels_backend/management/commands/utils.py
+++ b/panels_backend/management/commands/utils.py
@@ -10,16 +10,17 @@ def sortable_version(version: str) -> str:
     return ".".join(bit.zfill(5) for bit in str(version).split("."))
 
 
-def normalize_version(padded_version: str) -> float:
+def normalize_version(padded_version: str) -> str | float:
     """
     Turn '00001.00001' -> '1.1'
     """
     if not padded_version:
         return 0.0
 
-    return str(
-        float(".".join(bit.lstrip("0") for bit in padded_version.split(".")))
-    )
+    # TODO: fix issue where float conversion strips trailing 0s -
+    # e.g. 00005.00010 becomes 5.1 when it should be 5.10
+
+    return str(".".join(bit.lstrip("0") for bit in padded_version.split(".")))
 
 
 def parse_excluded_hgncs_from_file(file_path) -> set:

--- a/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_generate/test_format_output_data_genesuperpanels.py
@@ -21,7 +21,7 @@ class TestFormatGeneSuperPanels(TestCase):
                     "ci_superpanel__superpanel": 1,
                     "ci_superpanel__superpanel__external_id": "109",
                     "ci_superpanel__superpanel__panel_name": "First Panel",
-                    "ci_superpanel__superpanel__panel_version": "5",
+                    "ci_superpanel__superpanel__panel_version": "5.0",
                 }
             ],
             "R2": [
@@ -31,7 +31,7 @@ class TestFormatGeneSuperPanels(TestCase):
                     "ci_superpanel__superpanel": 2,
                     "ci_superpanel__superpanel__external_id": "209",
                     "ci_superpanel__superpanel__panel_name": "Second Panel",
-                    "ci_superpanel__superpanel__panel_version": "2",
+                    "ci_superpanel__superpanel__panel_version": "2.0",
                 }
             ],
         }
@@ -71,7 +71,7 @@ class TestFormatGeneSuperPanels(TestCase):
                     "ci_superpanel__superpanel": 1,
                     "ci_superpanel__superpanel__external_id": "109",
                     "ci_superpanel__superpanel__panel_name": "First Panel",
-                    "ci_superpanel__superpanel__panel_version": "5",
+                    "ci_superpanel__superpanel__panel_version": "5.0",
                 }
             ],
             "R2": [
@@ -81,7 +81,7 @@ class TestFormatGeneSuperPanels(TestCase):
                     "ci_superpanel__superpanel": 2,
                     "ci_superpanel__superpanel__external_id": "209",
                     "ci_superpanel__superpanel__panel_name": "Second Panel",
-                    "ci_superpanel__superpanel__panel_version": "2",
+                    "ci_superpanel__superpanel__panel_version": "2.0",
                 }
             ],
         }

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
@@ -42,6 +42,6 @@ class TestNormalizeVersion(TestCase):
                 == longer_expect_trails_zero
             )
         with self.subTest():
-            # None or None-evaluating types are turned into 0.0
-            assert normalize_version("") == 0.0
-            assert normalize_version(None) == 0.0
+            # None or None-evaluating types are turned into "0.0"
+            assert normalize_version("") == "0.0"
+            assert normalize_version(None) == "0.0"

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
@@ -6,7 +6,7 @@ from panels_backend.management.commands.utils import normalize_version
 class TestNormalizeVersion(TestCase):
     def setUp(self) -> None:
         return super().setUp()
-    
+
     def test_removes_zeros_correctly(self):
         """
         CASE: Version numbers AS STRINGS with decimal-points are provided.
@@ -15,6 +15,13 @@ class TestNormalizeVersion(TestCase):
         used to pad, but trailing 0s are left alone.
         Only one decimal place is tolerated
         """
+        with self.subTest():
+            zero_after_point_example = "00003.00000"
+            zero_after_point_example = "3.0"
+            assert (
+                normalize_version(zero_after_point_example)
+                == zero_after_point_example
+            )
         with self.subTest():
             easy_example = "00003.00002"
             easy_expect = "3.2"

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+
+from panels_backend.management.commands.utils import normalize_version
+
+
+class TestNormalizeVersion(TestCase):
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def test_removes_zeros_correctly(self):
+        """
+        CASE: Version numbers AS STRINGS with decimal-points are provided.
+        They contain zero-passing up to 5 spaces, to enable database sorting.
+        EXPECT: Zero-padding is removed, regardless of how many 0s are
+        used to pad, but trailing 0s are left alone.
+        Only one decimal place is tolerated
+        """
+        with self.subTest():
+            easy_example = "00003.00002"
+            easy_expect = "3.2"
+            assert normalize_version(easy_example) == easy_expect
+        with self.subTest():
+            middling_example = "00005.00010"
+            middling_expect = "5.10"
+            print(normalize_version(middling_example))
+            assert normalize_version(middling_example) == middling_expect
+        with self.subTest():
+            weirder_example = "00006.00010.00005"
+            weirder_expect = "6.10.5"
+            with self.assertRaises(ValueError):
+                assert normalize_version(weirder_example) == weirder_expect
+        with self.subTest():
+            # None or None-evaluating types are turned into 0.0
+            assert normalize_version("") == 0.0
+            assert normalize_version(None) == 0.0

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_normalize_version.py
@@ -29,13 +29,18 @@ class TestNormalizeVersion(TestCase):
         with self.subTest():
             middling_example = "00005.00010"
             middling_expect = "5.10"
-            print(normalize_version(middling_example))
             assert normalize_version(middling_example) == middling_expect
         with self.subTest():
             weirder_example = "00006.00010.00005"
             weirder_expect = "6.10.5"
-            with self.assertRaises(ValueError):
-                assert normalize_version(weirder_example) == weirder_expect
+            assert normalize_version(weirder_example) == weirder_expect
+        with self.subTest():
+            longer_example_trails_zero = "00006.00010.00005.00000"
+            longer_expect_trails_zero = "6.10.5.0"
+            assert (
+                normalize_version(longer_example_trails_zero)
+                == longer_expect_trails_zero
+            )
         with self.subTest():
             # None or None-evaluating types are turned into 0.0
             assert normalize_version("") == 0.0

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_parse_excluded_hgncs_from_file.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_parse_excluded_hgncs_from_file.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+import pandas as pd
+import unittest
+import unittest.mock as mock
+
+from panels_backend.management.commands.utils import parse_excluded_hgncs_from_file
+
+
+#TODO: write
+class TestParseExcludedHgncsFromFile(TestCase):
+    def setUp(self) -> None:
+        
+    

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_parse_excluded_hgncs_from_file.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_parse_excluded_hgncs_from_file.py
@@ -29,10 +29,12 @@ class TestParseExcludedHgncsFromFile(TestCase):
                         "alpha-1-B glycoprotein",
                         "A1BG antisense RNA 1",
                         "APOBEC1 complementation factor",
-                        "symbol withdrawn, see [HGNC:12469](/data/gene-symbol-report/#!/hgnc_id/HGNC:12469)",
+                        "symbol withdrawn, see [HGNC:12469](/data/gene-symbol-report/#!/"
+                        + "hgnc_id/HGNC:12469)",
                         "alpha-2-macroglobulin",
                         "A2M antisense RNA 1",
-                        "mitochondrially encoded ATP synthase membrane subunit 6",  # should filter out
+                        "mitochondrially encoded ATP synthase membrane subunit 6",
+                        # last entry should filter out
                     ]
                 ),
                 "RefSeq IDs": pd.Series(

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_parse_excluded_hgncs_from_file.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_parse_excluded_hgncs_from_file.py
@@ -3,11 +3,72 @@ import pandas as pd
 import unittest
 import unittest.mock as mock
 
-from panels_backend.management.commands.utils import parse_excluded_hgncs_from_file
+from panels_backend.management.commands.utils import (
+    parse_excluded_hgncs_from_file,
+)
 
 
-#TODO: write
 class TestParseExcludedHgncsFromFile(TestCase):
     def setUp(self) -> None:
-        
-    
+        # An example HGNC dataframe to use in the test
+        self.hgnc_dataframe = pd.DataFrame(
+            {
+                "HGNC ID": pd.Series(
+                    [
+                        "HGNC:5",
+                        "HGNC:37133",
+                        "HGNC:24086",
+                        "HGNC:6",
+                        "HGNC:7",
+                        "HGNC:27057",
+                        "HGNC:7414",
+                    ]
+                ),
+                "Approved name": pd.Series(
+                    [
+                        "alpha-1-B glycoprotein",
+                        "A1BG antisense RNA 1",
+                        "APOBEC1 complementation factor",
+                        "symbol withdrawn, see [HGNC:12469](/data/gene-symbol-report/#!/hgnc_id/HGNC:12469)",
+                        "alpha-2-macroglobulin",
+                        "A2M antisense RNA 1",
+                        "mitochondrially encoded ATP synthase membrane subunit 6",  # should filter out
+                    ]
+                ),
+                "RefSeq IDs": pd.Series(
+                    [
+                        "NM_130786",
+                        "NR_015380",
+                        "NM_014576",
+                        "",
+                        "NM_000014",
+                        "NR_026971",
+                        "YP_003024031",
+                    ]
+                ),
+                "Locus type": pd.Series(
+                    [
+                        "gene with protein product",
+                        "RNA, long non-coding",  # should filter out
+                        "gene with protein product",
+                        "unknown",
+                        "gene with protein product",
+                        "RNA, long non-coding",  # should filter out
+                        "gene with protein product",
+                    ]
+                ),
+            },
+        )
+
+    @mock.patch("panels_backend.management.commands.utils.pd.read_csv")
+    def test_parse_hgncs(self, mock_read_csv):
+        """
+        CASE: A dataframe containing 7 entries is parsed. Two are RNAs, and
+        one is mitochrondrially encoded.
+        EXPECT: The HGNCs of the 3 entries described in CASE are returned as
+        a set.
+        """
+        mock_read_csv.return_value = self.hgnc_dataframe
+        expected = set(["HGNC:7414", "HGNC:37133", "HGNC:27057"])
+        actual = parse_excluded_hgncs_from_file("/dev/null")
+        self.assertListEqual(list(expected), list(actual))

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_sortable_version.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_sortable_version.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+
+from panels_backend.management.commands.utils import sortable_version
+
+
+class TestSortableVersion(TestCase):
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def test_pads_correctly(self):
+        """
+        CASE: Version numbers AS STRINGS with decimal-points are provided
+        EXPECT: The numbers with decimals are zero-padded up to 5 spaces,
+        regardless of how many decimals there are
+        """
+        with self.subTest():
+            easy_example = "3.2"
+            easy_expect = "00003.00002"
+            assert sortable_version(easy_example) == easy_expect
+        with self.subTest():
+            middling_example = "5.10"
+            middling_expect = "00005.00010"
+            assert sortable_version(middling_example) == middling_expect
+        with self.subTest():
+            weirder_example = "6.10.5"
+            weirder_expect = "00006.00010.00005"
+            assert sortable_version(weirder_example) == weirder_expect

--- a/tests/test_panels_backend/test_management/test_commands/test_utils/test_sortable_version.py
+++ b/tests/test_panels_backend/test_management/test_commands/test_utils/test_sortable_version.py
@@ -6,7 +6,7 @@ from panels_backend.management.commands.utils import sortable_version
 class TestSortableVersion(TestCase):
     def setUp(self) -> None:
         return super().setUp()
-    
+
     def test_pads_correctly(self):
         """
         CASE: Version numbers AS STRINGS with decimal-points are provided


### PR DESCRIPTION
Added unit tests for the 3 functions in utils.py
I also made some slight changes to normalize_version, which was stripping right-hand zeroes during a float conversion step. This was turning valid panel versions such as 5.10 into 5.1, which would have been confusing when displayed to users.

Ran 159 tests in 5.209s

OK
Destroying test database for alias 'default'...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eris/95)
<!-- Reviewable:end -->
